### PR TITLE
Allows uploads dir to be a broken symlink

### DIFF
--- a/lib/modules/deploy.class.php
+++ b/lib/modules/deploy.class.php
@@ -188,7 +188,7 @@ class Deploy {
 
         // Is there stuff in shared? Does it look right?
         "wp-config.php is not in the shared directory." => !file_exists("{$new_release->release_dir}/../../shared/wp-config.php"),
-        "uploads directory is not in the shared directory." => !file_exists("{$new_release->release_dir}/../../shared/uploads"),
+        "uploads directory is not in the shared directory." => (!file_exists("{$new_release->release_dir}/../../shared/uploads")&&!is_link("{$new_release->release_dir}/../../shared/uploads")),
         "wp-config.php doesn't contain DB_NAME; is it valid?" => !strpos(file_get_contents("{$new_release->release_dir}/../../shared/wp-config.php"), "DB_NAME"),
 
         //
@@ -196,7 +196,7 @@ class Deploy {
         //
 
         "wp-config.php is missing; did the symlinking fail?" => !file_exists("{$new_release->release_dir}/wp-config.php"),
-        "wp-content/uploads is missing; did the symlinking fail?" => !file_exists("{$new_release->release_dir}/wp-content/uploads"),
+        "wp-content/uploads is missing; did the symlinking fail?" => (!file_exists("{$new_release->release_dir}/wp-content/uploads")&&!is_link("{$new_release->release_dir}/../../shared/uploads")),
       ];
 
       $release_ok = true;


### PR DESCRIPTION
Issue: https://github.com/dxw/whippet/issues/30

This hotfix still checks for 'shared/uploads', but allows it to be a broken symlink

This is for cases where 'shared/uploads' is a symlink to a mount that may temporarily unavailable. Currently, if the 'shared/uploads' symlinked mount is unavailable, the deploy will fail.