### PR TITLE
Remove <release-dir>/wp-content/uploads before symlinkery

### DIFF
--- a/lib/modules/deploy.class.php
+++ b/lib/modules/deploy.class.php
@@ -79,7 +79,10 @@ class Release {
 
     // Copy over wp-content
     $this->recurse_copy("{$this->project_dir}/wp-content","{$this->release_dir}/wp-content");
-
+    
+	if(file_exists("{$this->release_dir}/wp-content/uploads")) {
+		system("rm -rf {$this->release_dir}/wp-content/uploads");
+    }
 
     //
     // Remove unwanted git/test foo

--- a/lib/modules/deploy.class.php
+++ b/lib/modules/deploy.class.php
@@ -81,7 +81,7 @@ class Release {
     $this->recurse_copy("{$this->project_dir}/wp-content","{$this->release_dir}/wp-content");
     
 	if(file_exists("{$this->release_dir}/wp-content/uploads")) {
-		system("rm -rf {$this->release_dir}/wp-content/uploads");
+		$this->recurse_rm("{$this->release_dir}/wp-content/uploads");
     }
 
     //


### PR DESCRIPTION
Issue: https://github.com/dxw/whippet/issues/29

This will stop the symlink to 'shared/uploads' being created in 'wp-content/uploads/uploads', as it simply removes the directory if it is there before doing the symlinkery ... It only removes it from the release directory, so there isn't a possibility that it will delete precious user uploads (If they decide to run whippet deploy from a live project or whatever)

Although Issue https://github.com/dxw/whippet/issues/29 requested that it should fail and display an error, I think this is a possible solution to the issue.