### PR TITLE
Hotfix/change system calls to filesystem functions

### DIFF
--- a/generators/app/generate.php
+++ b/generators/app/generate.php
@@ -28,7 +28,6 @@ class AppGenerator extends WhippetGenerator {
       Git::init($this->target_dir);
     }
 
-    // The . is necessary for this command to work in Linux
-    system("cp -a " . dirname(__FILE__) . "/template/. {$this->target_dir}");
+    $this->recurse_copy(dirname(__FILE__) . "/template",$this->target_dir);
    }
 };

--- a/generators/migration/generate.php
+++ b/generators/migration/generate.php
@@ -218,12 +218,12 @@ class MigrationGenerator extends WhippetGenerator {
     echo "Copying project plugins\n";
     foreach($plugins as $plugin_file => $plugin_data) {
       if(dirname($plugin_file) != '.') {
-        system("cp -a '{$old}/plugins/" . dirname($plugin_file) . "/.' '{$new}/wp-content/plugins/" . dirname($plugin_file)  . "'");
+        $this->recurse_copy("{$old}/plugins/" . dirname($plugin_file), "{$new}/wp-content/plugins/" . dirname($plugin_file));
 
         $this->automatic_fixes[] = "Copied plugin directory " . dirname($plugin_file) . " into the project";
       }
       else {
-        system("cp '{$old}/plugins/{$plugin_file}' '{$new}/wp-content/plugins/'");
+        $this->recurse_copy("{$old}/plugins/{$plugin_file}", "{$new}/wp-content/plugins");
 
         $this->automatic_fixes[] = "Copied plugin file {$plugin_file} into the project";
       }
@@ -254,7 +254,7 @@ class MigrationGenerator extends WhippetGenerator {
         system("mkdir -p $new_theme_dir"); // For themes within subdirs
       }
 
-      system("cp -a '{$old}/themes/{$theme_dir}/.' '{$new_theme_dir}/{$theme_dir}'");
+      $this->recurse_copy("{$old}/themes/{$theme_dir}","{$new_theme_dir}/{$theme_dir}");
 
       $this->automatic_fixes[] = "Copied theme directory {$theme_dir} into the project";
 
@@ -290,7 +290,9 @@ class MigrationGenerator extends WhippetGenerator {
       echo "Copying language files\n";
 
       mkdir("{$new}/wp-content/languages/");
-      system("cp {$old}/languages/*.mo {$new}/wp-content/languages/");
+      foreach (glob("{$old}/languages/*.mo") as $file) {
+        copy($file, "{$new}/wp-content/languages/{$file}");
+      }
 
       $this->automatic_fixes[] = "Copied language directory into the project";
     }

--- a/generators/migration/generate.php
+++ b/generators/migration/generate.php
@@ -251,7 +251,7 @@ class MigrationGenerator extends WhippetGenerator {
       $new_theme_dir = "{$new}/wp-content/themes/" . dirname($theme_dir);
 
       if(!file_exists($new_theme_dir)) {
-        system("mkdir -p $new_theme_dir"); // For themes within subdirs
+        mkdir("{$new_theme_dir}",0755,true); // For themes within subdirs
       }
 
       $this->recurse_copy("{$old}/themes/{$theme_dir}","{$new_theme_dir}/{$theme_dir}");

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -23,8 +23,7 @@ class ThemeGenerator extends WhippetGenerator {
       mkdir($this->target_dir);
     }
 
-    // The . is necessary for this command to work in Linux
-    system("cp -a " . dirname(__FILE__) . "/template/. {$this->target_dir}");
+    $this->recurse_copy(dirname(__FILE__) . "/template", $this->target_dir);
 
     // Delete the spurious .git file
     system("rm {$this->target_dir}/.git");

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -26,6 +26,6 @@ class ThemeGenerator extends WhippetGenerator {
     $this->recurse_copy(dirname(__FILE__) . "/template", $this->target_dir);
 
     // Delete the spurious .git file
-    system("rm {$this->target_dir}/.git");
+    unlink("{$this->target_dir}/.git");
    }
 };

--- a/lib/modules/deploy.class.php
+++ b/lib/modules/deploy.class.php
@@ -75,8 +75,7 @@ class Release {
     $plugin->install();
 
     // Copy over wp-content
-    // TODO: Sorry, windows devs
-    system("cp -r {$this->project_dir}/wp-content {$this->release_dir}/wp-content");
+    $this->recurse_copy("{$this->project_dir}/wp-content","{$this->release_dir}/wp-content");
 
 
     //
@@ -94,7 +93,7 @@ class Release {
     // Copy public assets
     //
 
-    system("cp -r {$this->project_dir}/public/* {$this->release_dir}");
+	$this->recurse_copy("{$this->project_dir}/public","{$this->release_dir}");
 
 
     //

--- a/lib/modules/deploy.class.php
+++ b/lib/modules/deploy.class.php
@@ -227,7 +227,7 @@ class Deploy {
           $broken_release = $broken_release_prefix . "_{$count}";
         }
 
-        system("mv {$new_release->release_dir} {$broken_release}");
+        rename("{$new_release->release_dir}","{$broken_release}");
 
         echo "Problems:\n";
         echo implode($messages, "\n");
@@ -238,8 +238,8 @@ class Deploy {
       else{
         // If we are forcing, rejig some directories
         if($force) {
-          system("mv {$this->releases_dir}/{$new_release->deployed_commit} {$this->releases_dir}/{$new_release->deployed_commit}_" . ($new_release->number - 1));
-          system("mv {$new_release->release_dir} {$this->releases_dir}/{$new_release->deployed_commit}");
+          rename("{$this->releases_dir}/{$new_release->deployed_commit}","{$this->releases_dir}/{$new_release->deployed_commit}_" . ($new_release->number - 1));
+          rename("{$new_release->release_dir}","{$this->releases_dir}/{$new_release->deployed_commit}");
 
           $new_release->release_dir = "{$this->releases_dir}/{$new_release->deployed_commit}";
         }

--- a/lib/modules/deploy.class.php
+++ b/lib/modules/deploy.class.php
@@ -109,9 +109,8 @@ class Release {
 
 
     // Symlinkery
-    // TODO: Sorry, windows devs
-    system("ln -s " . realpath("{$this->release_dir}/../../shared/wp-config.php") . " {$this->release_dir}/wp-config.php");
-    system("ln -s " . realpath("{$this->release_dir}/../../shared/uploads") . " {$this->release_dir}/wp-content/uploads");
+    symlink(realpath("{$this->release_dir}/../../shared/wp-config.php"),"{$this->release_dir}/wp-config.php");
+    symlink(realpath("{$this->release_dir}/../../shared/uploads"),"{$this->release_dir}/wp-content/uploads");
 
     // FIN
   }
@@ -256,7 +255,7 @@ class Deploy {
           unlink("{$current}");
         }
 
-        system("ln -s " . realpath("{$new_release->release_dir}") . " {$current}");
+        symlink(realpath("{$new_release->release_dir}"),"{$current}");
 
         // Update manifest
         $release = new stdClass();

--- a/lib/modules/helpers/whippet_helpers.trait.php
+++ b/lib/modules/helpers/whippet_helpers.trait.php
@@ -86,7 +86,9 @@ trait whippet_helpers {
   // Modified to copy symlinks
   function recurse_copy($src,$dst) {
     $dir = opendir($src);
-    @mkdir($dst);
+    if(!is_dir($dst)&&!is_link($dst)) {
+    	mkdir($dst);
+    }
     while(false !== ( $file = readdir($dir)) ) {
       if (( $file != '.' ) && ( $file != '..' )) {
           if ( is_link($src . '/' . $file) ) {

--- a/lib/modules/helpers/whippet_helpers.trait.php
+++ b/lib/modules/helpers/whippet_helpers.trait.php
@@ -101,6 +101,22 @@ trait whippet_helpers {
     closedir($dir);
   }
 
+  // 100% credit:
+  // The suckiness of PHP
+  function recurse_rmdir($dir) {
+    $dir_handle = opendir($dir);
+    while(false !== ( $file = readdir($dir_handle) ) ) {
+      if (( $file != '.' ) && ( $file != '..' )) {
+        if ( is_dir($dir . '/' . $file) ) {
+          $this->recurse_rmdir($dir . '/' . $file);
+        } else {
+          unlink($dir . '/' . $file);
+        }
+      }
+    }
+    rmdir($dir);
+  }
+
 
   private function check_for_missing_whippet_files($project_dir) {
     $whippet_files = array(

--- a/lib/modules/helpers/whippet_helpers.trait.php
+++ b/lib/modules/helpers/whippet_helpers.trait.php
@@ -107,7 +107,9 @@ trait whippet_helpers {
     $dir_handle = opendir($dir);
     while(false !== ( $file = readdir($dir_handle) ) ) {
       if (( $file != '.' ) && ( $file != '..' )) {
-        if ( is_dir($dir . '/' . $file) ) {
+        if ( is_link($dir . '/' . $file) ) {
+          unlink($dir . '/' . $file);
+        } elseif ( is_dir($dir . '/' . $file) ) {
           $this->recurse_rmdir($dir . '/' . $file);
         } else {
           unlink($dir . '/' . $file);

--- a/lib/modules/helpers/whippet_helpers.trait.php
+++ b/lib/modules/helpers/whippet_helpers.trait.php
@@ -80,6 +80,27 @@ trait whippet_helpers {
     return false;
   }
 
+  // 77.079482% credit:
+  // gimmicklessgpt@gmail.com
+  // http://php.net/manual/en/function.copy.php
+  // Modified to copy symlinks
+  function recurse_copy($src,$dst) {
+    $dir = opendir($src);
+    @mkdir($dst);
+    while(false !== ( $file = readdir($dir)) ) {
+      if (( $file != '.' ) && ( $file != '..' )) {
+          if ( is_link($src . '/' . $file) ) {
+            symlink(readlink($src . '/' . $file), $dst . '/' . $file);
+          } elseif ( is_dir($src . '/' . $file) ) {
+            $this->recurse_copy($src . '/' . $file,$dst . '/' . $file);
+          } else {
+            copy($src . '/' . $file,$dst . '/' . $file);
+          }
+       }
+    }
+    closedir($dir);
+  }
+
 
   private function check_for_missing_whippet_files($project_dir) {
     $whippet_files = array(


### PR DESCRIPTION
Issue: https://github.com/dxw/whippet/issues/12

Adds a couple of functions in whippet_helpers to replicate `rm -r` and `cp -a`, and replaces the use of `system()` with PHP filesystem functions.