### PR TITLE
deps: Prevent multiple copies of the same plugin/theme in whippet.lock

### DIFF
--- a/src/Files/WhippetLock.php
+++ b/src/Files/WhippetLock.php
@@ -25,6 +25,14 @@ class WhippetLock extends Base
 
     public function addDependency(/* string */ $type, /* string */ $name, /* string */ $src, /* string */ $revision)
     {
+        if (isset($this->data[$type])) {
+            foreach ($this->data[$type] as $key => $dependency) {
+                if ($name === $dependency['name']) {
+                    array_splice($this->data[$type], $key, 1);
+                }
+            }
+        }
+
         $this->data[$type][] = [
             'name' => $name,
             'src' => $src,

--- a/tests/files/whippet_lock_test.php
+++ b/tests/files/whippet_lock_test.php
@@ -114,6 +114,38 @@ class Files_WhippetLock_Test extends PHPUnit_Framework_TestCase
         ], $whippetLock->getDependencies('plugins'));
     }
 
+    public function testAddDependencyThatAlreadyExists()
+    {
+        $whippetLock = new \Dxw\Whippet\Files\WhippetLock([
+            'plugins' => [
+                [
+                    'name' => 'my-other-plugin',
+                    'src' => 'git@git.dxw.net:foobar/bat',
+                    'revision' => 'zzz',
+                ],
+                [
+                    'name' => 'my-plugin',
+                    'src' => 'git@git.dxw.net:foobar/baz',
+                    'revision' => '456789',
+                ],
+            ],
+        ]);
+
+        $whippetLock->addDependency('plugins', 'my-plugin', 'git@git.dxw.net:foobar/baz', '123abc');
+        $this->assertEquals([
+            [
+                'name' => 'my-other-plugin',
+                'src' => 'git@git.dxw.net:foobar/bat',
+                'revision' => 'zzz',
+            ],
+            [
+                'name' => 'my-plugin',
+                'src' => 'git@git.dxw.net:foobar/baz',
+                'revision' => '123abc',
+            ],
+        ], $whippetLock->getDependencies('plugins'));
+    }
+
     public function testSaveToPath()
     {
         $dir = $this->getDir();


### PR DESCRIPTION
Running `whippet deps update` was causing `whippet.lock` to contain duplicate entries for plugins and themes.