### PR TITLE
Feature/update single dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,17 @@ This command will:
 3. Update `.gitignore` with the plugins/themes installed, and remove plugins/themes that are removed from `whippet.json`
 4. Run `whippet deps install`
 
+### whippet deps update [type]/[name]
+
+e.g. `whippet deps update plugins/twitget`
+
+This will:
+
+1. Check the commit hash for the ref of the specified repo, provided it is in `whippet.json`
+2. Update that repo in `whippet.lock`
+3. Update `.gitignore` if the repo was no previously installed
+4. Install the repo at the specified ref
+
 ### whippet plugins install
 
 This command will run through the items in `whippet.lock` and clone any missing plugins/themes, or fetch and checkout.

--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ This will:
 
 1. Check the commit hash for the ref of the specified repo, provided it is in `whippet.json`
 2. Update that repo in `whippet.lock`
-3. Update `.gitignore` if the repo was no previously installed
+3. Update `.gitignore` if the repo was not previously installed
 4. Install the repo at the specified ref
 
 ### whippet plugins install

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -33,12 +33,12 @@ class Updater
             return $result;
         }
 
-        $depArray = $this->jsonFile->getDependency($type, $name);
-        if ($depArray === []) {
+        $dep = $this->jsonFile->getDependency($type, $name);
+        if ($dep === []) {
             return \Result\Result::err('No matching dependency in whippet.json');
         }
 
-        return $this->update([$type=>[$depArray]]);
+        return $this->update([$type=>[$dep]]);
     }
 
     public function updateAll()

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -123,7 +123,7 @@ class Updater
     {
         foreach (['themes', 'plugins'] as $type) {
             foreach ($this->jsonFile->getDependencies($type) as $dep) {
-                $this->addDependencyToGitignore($type, $dep['name']);
+                $this->addDependencyToIgnoresArray($type, $dep['name']);
             }
         }
         $this->gitignore->save_ignores(array_unique($this->ignores));
@@ -150,7 +150,7 @@ class Updater
         }
     }
 
-    private function addDependencyToGitignore($type, $name)
+    private function addDependencyToIgnoresArray($type, $name)
     {
         $this->ignores[] = $this->getGitignoreDependencyLine($type, $name);
     }

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -59,6 +59,8 @@ class Updater
 
     private function update(array $dependencies)
     {
+        $this->updateHash();
+        $this->loadGitignore();
         $count = 0;
         foreach ($dependencies as $type => $typeDependencies) {
             foreach ($typeDependencies as $dep) {
@@ -84,8 +86,6 @@ class Updater
         if ($result->isErr()) {
             return $result;
         }
-        $this->updateHash();
-        $this->loadGitignore();
         return \Result\Result::ok();
     }
 

--- a/src/Files/WhippetJson.php
+++ b/src/Files/WhippetJson.php
@@ -13,6 +13,18 @@ class WhippetJson extends Base
         }
     }
 
+    public function getDependency(/* string */ $type, /* string */ $name)
+    {
+        if (isset($this->data[$type])) {
+            foreach ($this->getDependencies($type) as $dep) {
+                if ($dep['name'] === $name) {
+                    return $dep;
+                }
+            }
+        }
+        return [];
+    }
+
     public function getSources()
     {
         return $this->data['src'];

--- a/src/Modules/Dependencies.php
+++ b/src/Modules/Dependencies.php
@@ -42,13 +42,13 @@ class Dependencies extends \RubbishThorClone
         $this->exitIfError($installer->install());
     }
 
-    public function update()
+    public function update($dep = null)
     {
         $dir = $this->getDirectory();
         $updater = new \Dxw\Whippet\Dependencies\Updater($this->factory, $dir);
         $installer = new \Dxw\Whippet\Dependencies\Installer($this->factory, $dir);
 
-        $this->exitIfError($updater->update());
+        $this->exitIfError($updater->update($dep));
         $this->exitIfError($installer->install());
     }
 

--- a/src/Modules/Dependencies.php
+++ b/src/Modules/Dependencies.php
@@ -15,7 +15,7 @@ class Dependencies extends \RubbishThorClone
     public function commands()
     {
         $this->command('install', 'Installs dependencies');
-        $this->command('update', 'Updates dependencies to their latest versions');
+        $this->command('update', 'Updates dependencies to their latest versions. Use deps update [type]/[name] to update a specific dependency');
         $this->command('migrate', 'Converts legacy plugins file to whippet.json');
     }
 
@@ -39,7 +39,7 @@ class Dependencies extends \RubbishThorClone
         $dir = $this->getDirectory();
         $installer = new \Dxw\Whippet\Dependencies\Installer($this->factory, $dir);
 
-        $this->exitIfError($installer->install());
+        $this->exitIfError($installer->installAll());
     }
 
     public function update($dep = null)
@@ -50,10 +50,10 @@ class Dependencies extends \RubbishThorClone
 
         if (is_null($dep)) {
             $this->exitIfError($updater->updateAll());
-            $this->exitIfError($installer->install());
+            $this->exitIfError($installer->installAll());
         } else {
             $this->exitIfError($updater->updateSingle($dep));
-            $this->exitIfError($installer->install($dep));
+            $this->exitIfError($installer->installSingle($dep));
         }
     }
 

--- a/src/Modules/Dependencies.php
+++ b/src/Modules/Dependencies.php
@@ -48,8 +48,13 @@ class Dependencies extends \RubbishThorClone
         $updater = new \Dxw\Whippet\Dependencies\Updater($this->factory, $dir);
         $installer = new \Dxw\Whippet\Dependencies\Installer($this->factory, $dir);
 
-        $this->exitIfError($updater->update($dep));
-        $this->exitIfError($installer->install($dep));
+        if (is_null($dep)) {
+            $this->exitIfError($updater->updateAll());
+            $this->exitIfError($installer->install());
+        } else {
+            $this->exitIfError($updater->updateSingle($dep));
+            $this->exitIfError($installer->install($dep));
+        }
     }
 
     public function migrate()

--- a/src/Modules/Dependencies.php
+++ b/src/Modules/Dependencies.php
@@ -49,7 +49,7 @@ class Dependencies extends \RubbishThorClone
         $installer = new \Dxw\Whippet\Dependencies\Installer($this->factory, $dir);
 
         $this->exitIfError($updater->update($dep));
-        $this->exitIfError($installer->install());
+        $this->exitIfError($installer->install($dep));
     }
 
     public function migrate()

--- a/tests/dependencies/installer_test.php
+++ b/tests/dependencies/installer_test.php
@@ -4,7 +4,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
 {
     use \Helpers;
 
-    public function testInstall()
+    public function testInstallAll()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -46,14 +46,14 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Adding themes/my-theme]\ngit clone output\ngit checkout output\n[Adding plugins/my-plugin]\ngit clone output\ngit checkout output\n[Adding plugins/another-plugin]\ngit clone output\ngit checkout output\n", $output);
     }
 
-    public function testInstallThemeAlreadyCloned()
+    public function testInstallAllThemeAlreadyCloned()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -82,14 +82,14 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Checking themes/my-theme]\ngit checkout output\n", $output);
     }
 
-    public function testInstallMissingWhippetJson()
+    public function testInstallAllMissingWhippetJson()
     {
         $dir = $this->getDir();
 
@@ -99,7 +99,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertEquals(true, $result->isErr());
@@ -107,7 +107,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $output);
     }
 
-    public function testInstallMissingWhippetLock()
+    public function testInstallAllMissingWhippetLock()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -120,7 +120,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertEquals(true, $result->isErr());
@@ -128,7 +128,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $output);
     }
 
-    public function testInstallWrongHash()
+    public function testInstallAllWrongHash()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -143,7 +143,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertEquals(true, $result->isErr());
@@ -151,7 +151,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $output);
     }
 
-    public function testInstallCloneFails()
+    public function testInstallAllCloneFails()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -178,7 +178,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -186,7 +186,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("[Adding themes/my-theme]\ngit clone output\n", $output);
     }
 
-    public function testInstallCheckoutFails()
+    public function testInstallAllCheckoutFails()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -213,7 +213,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -221,7 +221,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("[Adding themes/my-theme]\ngit clone output\ngit checkout output\n", $output);
     }
 
-    public function testInstallBlankLockfile()
+    public function testInstallAllBlankLockfile()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -239,7 +239,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install();
+        $result = $dependencies->installAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
@@ -283,7 +283,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
             $this->getProjectDirectory($dir)
         );
         ob_start();
-        $result = $dependencies->install('plugins/my-plugin');
+        $result = $dependencies->installSingle('plugins/my-plugin');
         $output = ob_get_clean();
 
         $this->assertEquals("[Checking plugins/my-plugin]\ngit checkout output\n", $output);
@@ -327,7 +327,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
             $this->getProjectDirectory($dir)
         );
         ob_start();
-        $result = $dependencies->install('plugins/my-plugin');
+        $result = $dependencies->installSingle('plugins/my-plugin');
         $output = ob_get_clean();
 
         $this->assertEquals("[Adding plugins/my-plugin]\ngit clone output\ngit checkout output\n", $output);
@@ -361,7 +361,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install('themes/my-theme');
+        $result = $dependencies->installSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -396,7 +396,7 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->install('themes/my-theme');
+        $result = $dependencies->installSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());

--- a/tests/dependencies/installer_test.php
+++ b/tests/dependencies/installer_test.php
@@ -245,4 +245,162 @@ class Dependencies_Installer_Test extends PHPUnit_Framework_TestCase
         $this->assertFalse($result->isErr());
         $this->assertEquals("whippet.lock contains nothing to install\n", $output);
     }
+
+    public function testInstallSingle()
+    {
+        $dir = $this->getDir();
+        file_put_contents($dir.'/whippet.json', 'foobar');
+        file_put_contents($dir.'/whippet.lock', 'foobar');
+
+        $whippetLock = $this->getWhippetLock(sha1('foobar'), [
+            'themes' => [
+                [
+                    'name' => 'my-theme',
+                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'revision' => '27ba906',
+                ],
+            ],
+            'plugins' => [
+                [
+                    'name' => 'my-plugin',
+                    'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+                    'revision' => '123456',
+                ],
+                [
+                    'name' => 'another-plugin',
+                    'src' => 'git@git.dxw.net:wordpress-plugins/another-plugin',
+                    'revision' => '789abc',
+                ],
+            ],
+        ]);
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
+
+        $gitMyPlugin = $this->getGit(true, null, '123456');
+        $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
+
+        $dependencies = new \Dxw\Whippet\Dependencies\Installer(
+            $this->getFactory(),
+            $this->getProjectDirectory($dir)
+        );
+        ob_start();
+        $result = $dependencies->install('plugins/my-plugin');
+        $output = ob_get_clean();
+
+        $this->assertEquals("[Checking plugins/my-plugin]\ngit checkout output\n", $output);
+        $this->assertFalse($result->isErr());
+    }
+
+    public function testInstallSingleAlreadyCloned()
+    {
+        $dir = $this->getDir();
+        file_put_contents($dir.'/whippet.json', 'foobar');
+        file_put_contents($dir.'/whippet.lock', 'foobar');
+
+        $whippetLock = $this->getWhippetLock(sha1('foobar'), [
+            'themes' => [
+                [
+                    'name' => 'my-theme',
+                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'revision' => '27ba906',
+                ],
+            ],
+            'plugins' => [
+                [
+                    'name' => 'my-plugin',
+                    'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+                    'revision' => '123456',
+                ],
+                [
+                    'name' => 'another-plugin',
+                    'src' => 'git@git.dxw.net:wordpress-plugins/another-plugin',
+                    'revision' => '789abc',
+                ],
+            ],
+        ]);
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
+
+        $gitMyPlugin = $this->getGit(false, 'git@git.dxw.net:wordpress-plugins/my-plugin', '123456');
+        $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
+
+        $dependencies = new \Dxw\Whippet\Dependencies\Installer(
+            $this->getFactory(),
+            $this->getProjectDirectory($dir)
+        );
+        ob_start();
+        $result = $dependencies->install('plugins/my-plugin');
+        $output = ob_get_clean();
+
+        $this->assertEquals("[Adding plugins/my-plugin]\ngit clone output\ngit checkout output\n", $output);
+        $this->assertFalse($result->isErr());
+    }
+
+    public function testInstallSingleCloneFails()
+    {
+        $dir = $this->getDir();
+        file_put_contents($dir.'/whippet.json', 'foobar');
+        file_put_contents($dir.'/whippet.lock', 'foobar');
+
+        $whippetLock = $this->getWhippetLock(sha1('foobar'), [
+            'themes' => [
+                [
+                    'name' => 'my-theme',
+                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'revision' => '27ba906',
+                ],
+            ],
+            'plugins' => [],
+        ]);
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
+
+        $gitMyTheme = $this->getGit(false, ['with' => 'git@git.dxw.net:wordpress-themes/my-theme', 'return' => false], null);
+        $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
+
+        $dependencies = new \Dxw\Whippet\Dependencies\Installer(
+            $this->getFactory(),
+            $this->getProjectDirectory($dir)
+        );
+
+        ob_start();
+        $result = $dependencies->install('themes/my-theme');
+        $output = ob_get_clean();
+
+        $this->assertTrue($result->isErr());
+        $this->assertEquals('could not clone repository', $result->getErr());
+        $this->assertEquals("[Adding themes/my-theme]\ngit clone output\n", $output);
+    }
+
+    public function testInstallSingleCheckoutFails()
+    {
+        $dir = $this->getDir();
+        file_put_contents($dir.'/whippet.json', 'foobar');
+        file_put_contents($dir.'/whippet.lock', 'foobar');
+
+        $whippetLock = $this->getWhippetLock(sha1('foobar'), [
+            'themes' => [
+                [
+                    'name' => 'my-theme',
+                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'revision' => '27ba906',
+                ],
+            ],
+            'plugins' => [],
+        ]);
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
+
+        $gitMyTheme = $this->getGit(false, 'git@git.dxw.net:wordpress-themes/my-theme', ['with' => '27ba906', 'return' => false]);
+        $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
+
+        $dependencies = new \Dxw\Whippet\Dependencies\Installer(
+            $this->getFactory(),
+            $this->getProjectDirectory($dir)
+        );
+
+        ob_start();
+        $result = $dependencies->install('themes/my-theme');
+        $output = ob_get_clean();
+
+        $this->assertTrue($result->isErr());
+        $this->assertEquals('could not checkout revision', $result->getErr());
+        $this->assertEquals("[Adding themes/my-theme]\ngit clone output\ngit checkout output\n", $output);
+    }
 }

--- a/tests/dependencies/updater_test.php
+++ b/tests/dependencies/updater_test.php
@@ -62,7 +62,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         return $whippetLock;
     }
 
-    public function testUpdate()
+    public function testUpdateAll()
     {
         $dir = $this->getDir();
 
@@ -109,14 +109,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n[Updating plugins/my-plugin]\n", $output);
     }
 
-    public function testUpdateWithExistingGitignore()
+    public function testUpdateAllWithExistingGitignore()
     {
         $dir = $this->getDir();
         touch($dir.'/.gitignore');
@@ -161,14 +161,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateWithExistingGitignoreNoDuplication()
+    public function testUpdateAllWithExistingGitignoreNoDuplication()
     {
         $dir = $this->getDir();
         touch($dir.'/.gitignore');
@@ -214,14 +214,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateFailedGitCommand()
+    public function testUpdateAllFailedGitCommand()
     {
         $dir = $this->getDir();
 
@@ -256,7 +256,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -264,7 +264,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateWithExplicitSrc()
+    public function testUpdateAllWithExplicitSrc()
     {
         $dir = $this->getDir();
 
@@ -302,14 +302,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateWithoutRef()
+    public function testUpdateAllWithoutRef()
     {
         $dir = $this->getDir();
 
@@ -345,14 +345,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateBlankJsonfile()
+    public function testUpdateAllBlankJsonfile()
     {
         $dir = $this->getDir();
 
@@ -373,14 +373,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("whippet.json contains no dependencies\n", $output);
     }
 
-    public function testUpdateNoGitignore()
+    public function testUpdateAllNoGitignore()
     {
         $dir = $this->getDir();
 
@@ -427,14 +427,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n[Updating plugins/my-plugin]\n", $output);
     }
 
-    public function testUpdateRemoveFromGitignore()
+    public function testUpdateAllRemoveFromGitignore()
     {
         $dir = $this->getDir();
         touch($dir.'/.gitignore');
@@ -483,14 +483,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateBubbleErrors()
+    public function testUpdateAllBubbleErrors()
     {
         $dir = $this->getDir();
 
@@ -502,7 +502,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -510,7 +510,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $output);
     }
 
-    public function testUpdateNoExistingWhippetLock()
+    public function testUpdateAllNoExistingWhippetLock()
     {
         $dir = $this->getDir();
 
@@ -558,14 +558,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n[Updating plugins/my-plugin]\n", $output);
     }
 
-    public function testUpdateWithBrokenJson()
+    public function testUpdateAllWithBrokenJson()
     {
         $dir = $this->getDir();
 
@@ -608,7 +608,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update();
+        $result = $dependencies->updateAll();
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -616,29 +616,9 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyWithNoLock()
+    public function testUpdateSingleWithNoLock()
     {
         $dir = $this->getDir();
-        $whippetJson = $this->getWhippetJson([
-            'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
-            ],
-            'themes' => [
-                [
-                    'name' => 'my-theme',
-                    'ref' => 'v1.4',
-                ],
-            ],
-            'plugins' => [
-                [
-                    'name' => 'my-plugin',
-                    'ref' => 'v1.6',
-                ],
-            ],
-        ]);
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
-
-        file_put_contents($dir.'/whippet.json', 'foobar');
 
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::err('file not found'));
 
@@ -648,7 +628,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('twitget');
+        $result = $dependencies->updateSingle('twitget');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -656,27 +636,9 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('whippet.lock: file not found', $result->getErr());
     }
 
-    public function testUpdateDependencyIncorrectFormat()
+    public function testUpdateSingleIncorrectFormat()
     {
         $dir = $this->getDir();
-        $whippetJson = $this->getWhippetJson([
-            'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
-            ],
-            'themes' => [
-                [
-                    'name' => 'my-theme',
-                    'ref' => 'v1.4',
-                ],
-            ],
-            'plugins' => [
-                [
-                    'name' => 'my-plugin',
-                    'ref' => 'v1.6',
-                ],
-            ],
-        ]);
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
         file_put_contents($dir.'/whippet.json', 'foobar');
 
@@ -689,7 +651,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('twitget');
+        $result = $dependencies->updateSingle('twitget');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -697,7 +659,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals('Incorrect dependency format', $result->getErr());
     }
 
-    public function testUpdateDependencyNoMatch()
+    public function testUpdateSingleNoMatch()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -721,7 +683,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
 
-        $whippetLock = [];
+        $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
@@ -730,14 +692,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('plugins/twitget');
+        $result = $dependencies->updateSingle('plugins/twitget');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
         $this->assertEquals('No matching dependency in whippet.json', $result->getErr());
     }
 
-    public function testUpdateDependencyBrokenJson()
+    public function testUpdateSingleBrokenJson()
     {
         $dir = $this->getDir();
 
@@ -780,7 +742,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -788,7 +750,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyWithExistingGitignore()
+    public function testUpdateSingleWithExistingGitignore()
     {
         $dir = $this->getDir();
         touch($dir.'/.gitignore');
@@ -833,14 +795,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyWithExistingGitignoreNoDuplication()
+    public function testUpdateSingleWithExistingGitignoreNoDuplication()
     {
         $dir = $this->getDir();
         touch($dir.'/.gitignore');
@@ -886,14 +848,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyFailedGitCommand()
+    public function testUpdateSingleFailedGitCommand()
     {
         $dir = $this->getDir();
 
@@ -933,7 +895,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
@@ -941,7 +903,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyWithExplicitSrc()
+    public function testUpdateSingleWithExplicitSrc()
     {
         $dir = $this->getDir();
 
@@ -988,14 +950,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyWithoutRef()
+    public function testUpdateSingleWithoutRef()
     {
         $dir = $this->getDir();
 
@@ -1037,14 +999,14 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
         $this->assertEquals("[Updating themes/my-theme]\n", $output);
     }
 
-    public function testUpdateDependencyNoGitignore()
+    public function testUpdateSingleNoGitignore()
     {
         $dir = $this->getDir();
 
@@ -1090,7 +1052,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('themes/my-theme');
+        $result = $dependencies->updateSingle('themes/my-theme');
         $output = ob_get_clean();
 
         $this->assertFalse($result->isErr());
@@ -1098,7 +1060,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
     }
 
 
-    public function testUpdateDependency()
+    public function testUpdateSingle()
     {
         $dir = $this->getDir();
         file_put_contents($dir.'/whippet.json', 'foobar');
@@ -1143,7 +1105,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         );
 
         ob_start();
-        $result = $dependencies->update('plugins/my-plugin');
+        $result = $dependencies->updateSingle('plugins/my-plugin');
         $output = ob_get_clean();
 
         $this->assertEquals("[Updating plugins/my-plugin]\n", $output);

--- a/tests/dependencies/updater_test.php
+++ b/tests/dependencies/updater_test.php
@@ -26,7 +26,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         return $gitignore;
     }
 
-    private function getWhippetLockWritable(array $addDependency, /* string */ $hash, /* string */ $path, array $getDependencies)
+    private function getWhippetLockWritable(array $addDependency, /* string */ $hash, /* string */ $path, array $getDependencies, /* boolean */ $setHash = true)
     {
         $whippetLock = $this->getMockBuilder('\\Dxw\\Whippet\\Files\\WhippetLock')
         ->disableOriginalConstructor()
@@ -41,7 +41,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
             $addDependency
         );
 
-        $whippetLock->expects($this->exactly(1))
+        $whippetLock->expects($this->exactly($setHash === true ? 1 : 0))
         ->method('setHash')
         ->with($hash);
 
@@ -683,7 +683,7 @@ class Dependencies_Updater_Test extends PHPUnit_Framework_TestCase
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
 
-        $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, []);
+        $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, [], false);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(

--- a/tests/files/whippet_json_test.php
+++ b/tests/files/whippet_json_test.php
@@ -36,4 +36,32 @@ class Files_WhippetJson_Test extends PHPUnit_Framework_TestCase
             'plugins' => 'git@git.dxw.net:wordpress-plugins/',
         ], $whippetJson->getSources());
     }
+
+    public function testGetDependencyNoMatch()
+    {
+        $whippetJson = new \Dxw\Whippet\Files\WhippetJson([
+            'plugins' => [
+                [
+                    'name' => 'advanced-custom-fields',
+                    'ref' => 'foobar',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([], $whippetJson->getDependency('plugins', 'twitget'));
+    }
+
+    public function testGetDependency()
+    {
+        $whippetJson = new \Dxw\Whippet\Files\WhippetJson([
+            'plugins' => [
+                [
+                    'name' => 'twitget',
+                    'ref' => 'foobar',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['name'=>'twitget', 'ref'=>'foobar'], $whippetJson->getDependency('plugins', 'twitget'));
+    }
 }


### PR DESCRIPTION
Allows for updating a specific dependency from `whippet.json`, using `whippet deps update [type]/[name]`. 

Because of the current implementation, a significant amount of the tests essentially duplicate tests that are already in place for `whippet deps update`, but I have left them in place in case the implementation is changed in future.

Resolves #64.

