### PR TITLE
Fix `whippet deploy` PHP Fatal call to private

### DIFF
--- a/src/Modules/Release.php
+++ b/src/Modules/Release.php
@@ -84,7 +84,7 @@ class Release
         }
 
         // Make sure wp-content is up to date
-        $result = $installer->install(true);
+        $result = $installer->installAll();
         if ($result->isErr()) {
             echo sprintf("ERROR: %s\n", $result->getErr());
             exit(1);


### PR DESCRIPTION
#### Because:

* `whippet deploy` is throwing a PHP Fatal error and failing deploy on
  the current version of the `master` branch.
* It appears https://github.com/dxw/whippet/commit/8caec0efe94876e5384a755074695fe3645e86b1 introduced a change that replaced the public `install()` function on the `Installer` class with `installAll()`, but did not update the call in the `Release` class.

Fixes #101