### PR TITLE
(fix) Missing apache config for sub-dir multisites

### DIFF
--- a/docker-images/whippet-wordpress/wordpress.conf
+++ b/docker-images/whippet-wordpress/wordpress.conf
@@ -1,4 +1,4 @@
-<Directory />
+<Directory /var/www/html/>
         RewriteEngine On
         RewriteBase /
         RewriteRule ^index\.php$ - [L]


### PR DESCRIPTION
#### Because:

* `whippet server` appears to be ignoring the multisite redirect config
  in `/etc/apache2/sites-enabled/wordpress.conf`.
* Requests to theme assets within multisite paths are returning `404`s,
  however requests to the same assets on the root site are returning
  `200`s.
* See #107 for details.

#### This change:

* Sets the `<Directory>` path to `/var/www/html/`.
* This is more specific, but should introduce any issues as the docroot
  for the only site within the container is `/var/www/html`.

Fixes #107