### PR TITLE
'Generate theme' clones the whippet-theme-template repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "generators/theme/template"]
-	path = generators/theme/template
-	url = https://github.com/dxw/whippet-theme-template.git

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -5,7 +5,7 @@ use Dxw\Whippet\Git\Git;
 class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
   use \Dxw\Whippet\Modules\Helpers\WhippetHelpers;
 
-  protected $whippet_theme_repo = 'git@github.com:dxw/whippet-theme-template.git';
+  protected $whippet_theme_repo = 'https://github.com/dxw/whippet-theme-template.git';
 
   function __construct($options) {
     $this->options = $options;
@@ -27,8 +27,8 @@ class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
 
     (new Git($this->target_dir))->clone_repo($this->whippet_theme_repo);
     // Delete the spurious .git file
-    chdir("{$this->target_dir}");
-    exec('rm -rf .git');
+    chdir($this->target_dir);
+    $this->recurse_rm('.git');
 
     $namespace = $this->get_namespace_from_target_dir();
     echo "Setting namespace to {$namespace}\n";

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -11,7 +11,7 @@ class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
     $this->options = $options;
 
     if(isset($this->options->directory)) {
-      $this->target_dir = $this->options->directory;
+      $this->target_dir = getcwd() . '/' . $this->options->directory;
     }
     else {
       $this->target_dir = getcwd() . "/whippet-theme";
@@ -32,7 +32,7 @@ class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
 
     $namespace = $this->get_namespace_from_target_dir();
     echo "Setting namespace to {$namespace}\n";
-    exec(sprintf("find . -type f -exec sed -i '' -e 's/MyTheme/%s/g' {} \;", escapeshellarg($namespace)));
+    $this->find_and_replace($this->target_dir, 'MyTheme', $namespace);
    }
 
   function get_namespace_from_target_dir()

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -1,7 +1,11 @@
 <?php
 
+use Dxw\Whippet\Git\Git;
+
 class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
   use \Dxw\Whippet\Modules\Helpers\WhippetHelpers;
+
+  protected $whippet_theme_repo = 'git@github.com:dxw/whippet-theme-template.git';
 
   function __construct($options) {
     $this->options = $options;
@@ -21,9 +25,20 @@ class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
       mkdir($this->target_dir);
     }
 
-    $this->recurse_copy(dirname(__FILE__) . "/template", $this->target_dir);
-
+    (new Git($this->target_dir))->clone_repo($this->whippet_theme_repo);
     // Delete the spurious .git file
-    unlink("{$this->target_dir}/.git");
+    chdir("{$this->target_dir}");
+    exec('rm -rf .git');
+
+    $namespace = $this->get_namespace_from_target_dir();
+    echo "Setting namespace to {$namespace}\n";
+    exec(sprintf("find . -type f -exec sed -i '' -e 's/MyTheme/%s/g' {} \;", escapeshellarg($namespace)));
    }
+
+  function get_namespace_from_target_dir()
+  {
+    $base_dir = basename($this->target_dir);
+    $words = explode('-', $base_dir);
+    return implode('', array_map('ucfirst', $words));
+  }
 };

--- a/src/Modules/Helpers/WhippetHelpers.php
+++ b/src/Modules/Helpers/WhippetHelpers.php
@@ -167,4 +167,28 @@ trait WhippetHelpers
             exit(1);
         }
     }
+
+    public function find_and_replace($dir, $find, $replaceWith)
+    {
+        $files = $this->recurse_file_search($dir);
+        foreach ($files as $filename) {
+            if (is_file($filename) && is_writable($filename)) {
+                $file = file_get_contents($filename);
+                file_put_contents($filename, str_replace($find, $replaceWith, $file));
+            }
+        }
+    }
+
+    public function recurse_file_search($dir)
+    {
+        $recursive_iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+        $files = [];
+        foreach ($recursive_iterator as $file) {
+            if ($file->isDir()) {
+                continue;
+            }
+            $files[] = $file->getPathname();
+        }
+        return $files;
+    }
 };


### PR DESCRIPTION
- Replaced copying theme submodule folder with clone of whippet-theme repo
- Sets namespace of new theme

The problem with having 'generate' copy files from a submodule is that the submodule can easily get out date and the developer may not know there has been an update for it.

This PR will clone down the latest `whippet-theme-template` in to the correct directory, ensuring the developer is using the latest copy of our base theme.

I had to change the unlink to a system call to remove the .git folder as there was an issue with PHP not having the permission to remove the cloned dir.

Also included a simple function to rename the namespace of the newly created theme to a camel cased version of the directory name

In a future PR we will include a setup script that does `composer install` and all the other commands to get up and running