### PR TITLE
Update references to git.dxw.net

### DIFF
--- a/generators/migration/generate.php
+++ b/generators/migration/generate.php
@@ -107,7 +107,7 @@ class MigrationGenerator extends \Dxw\Whippet\WhippetGenerator {
 
     // Always start with a fresh file
     // Whippet init adds akismet (as it is part of the WP distro) but we only want it now if it's in $old
-    file_put_contents("{$new}/plugins", "source = \"git@git.dxw.net:wordpress-plugins/\"\n");
+    file_put_contents("{$new}/plugins", "source = \"git@git.govpress.com:wordpress-plugins/\"\n");
 
     echo "Updating Plugins file\n";
     foreach($plugins as $plugin_file => $plugin_data) {
@@ -187,7 +187,7 @@ class MigrationGenerator extends \Dxw\Whippet\WhippetGenerator {
         continue;
       }
 
-      if(strpos($remote, "git@git.dxw.net") === false) {
+      if(strpos($remote, "git@git.govpress.com") === false) {
         $this->manual_fixes[] = "Non-dxw git repo submoduled: {$remote} at {$submodule->dir}";
       }
 

--- a/readme.md
+++ b/readme.md
@@ -114,15 +114,15 @@ To manage plugins and themes using Whippet, you make entries in the `whippet.jso
 
 The file should specify a source for plugins and themes. The source should be a base url for a git repo.
 
-If you are a dxw customer, the sources will be `git@git.dxw.net:wordpress-plugins/` and `git@git.dxw.net:wordpress-themes/`. If not, we suggest using `https://github.com/wp-plugins` for plugins.
+If you are a dxw customer, the source will be `git@git.govpress.com:wordpress-plugins/`. If not, we suggest using `https://github.com/wp-plugins` for plugins.
 
 The rest of the file should specify plugins and themes that you want to install. Example:
 
 ```
 {
     "src": {
-        "plugins": "git@git.dxw.net:wordpress-plugins/",
-        "themes": "git@git.dxw.net:wordpress-themes/"
+        "plugins": "git@git.govpress.com:wordpress-plugins/",
+        "themes": "git@git.govpress.com:wordpress-themes/"
     },
     "plugins": [
         {"name": "akismet"}
@@ -138,7 +138,7 @@ The rest of the file should specify plugins and themes that you want to install.
 The `{"name": "akismet"}` instructs Whippet (on request) to install the most recent version of Akismet available in the repo. Whippet will determine a valid repo URL for the akismet plugin by appending the name to the source. In this example:
 
 ```
-git@git.dxw.net:wordpress-plugins/akismet
+git@git.govpress.com:wordpress-plugins/akismet
 ```
 
 You can also specify a particular label or branch that you want to use. Generally, this will either be master (the default) or a tag (for a specific version), but you can use any git reference. So you can do:

--- a/src/Dependencies/Migration.php
+++ b/src/Dependencies/Migration.php
@@ -103,7 +103,7 @@ class Migration
 
             if ($plugin == 'source') {
                 if (empty($data)) {
-                    return \Result\Result::err("Source is empty. It should just specify a repo root:\n\n  source = 'git@git.dxw.net:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.");
+                    return \Result\Result::err("Source is empty. It should just specify a repo root:\n\n  source = 'git@git.govpress.com:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.");
                 }
 
                 $source = $data;

--- a/src/Modules/Helpers/ManifestIo.php
+++ b/src/Modules/Helpers/ManifestIo.php
@@ -40,7 +40,7 @@ trait ManifestIo
 
             if ($plugin == 'source') {
                 if (empty($data)) {
-                    echo "Source is empty. It should just specify a repo root:\n\n  source = 'git@git.dxw.net:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.";
+                    echo "Source is empty. It should just specify a repo root:\n\n  source = 'git@git.govpress.com:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.";
                     exit(1);
                 }
 

--- a/src/Modules/Helpers/WhippetHelpers.php
+++ b/src/Modules/Helpers/WhippetHelpers.php
@@ -52,7 +52,7 @@ trait WhippetHelpers
             $this->application_config = json_decode('
             {
                 "wordpress": {
-                    "repository": "git@git.dxw.net:wordpress/snapshot",
+                    "repository": "git@git.govpress.com:wordpress/snapshot",
                     "revision": "master"
                 }
             }

--- a/tests/dependencies/installer_test.php
+++ b/tests/dependencies/installer_test.php
@@ -17,19 +17,19 @@ class DependenciesInstallerTest extends \PHPUnit\Framework\TestCase
 
         $my_theme = [
             'name' => 'my-theme',
-            'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+            'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
             'revision' => '27ba906',
         ];
 
         $my_plugin = [
             'name' => 'my-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
             'revision' => '123456',
         ];
 
         $another_plugin = [
             'name' => 'another-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/another-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
             'revision' => '789abc',
         ];
 
@@ -44,11 +44,11 @@ class DependenciesInstallerTest extends \PHPUnit\Framework\TestCase
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyTheme = $this->getGit(false, 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906');
+        $gitMyTheme = $this->getGit(false, 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906');
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
-        $gitMyPlugin = $this->getGit(false, 'git@git.dxw.net:wordpress-plugins/my-plugin', '123456');
+        $gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456');
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
-        $gitAnotherPlugin = $this->getGit(false, 'git@git.dxw.net:wordpress-plugins/another-plugin', '789abc');
+        $gitAnotherPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/another-plugin', '789abc');
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/another-plugin', $gitAnotherPlugin);
 
         $inspection_check_results = function ($type, $dep) {
@@ -115,7 +115,7 @@ EOT;
 
         $my_plugin = [
             'name' => 'my-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
             'revision' => '123456',
         ];
 
@@ -127,7 +127,7 @@ EOT;
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyPlugin = $this->getGit(false, 'git@git.dxw.net:wordpress-plugins/my-plugin', '123456');
+        $gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456');
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
 
         $inspection_check_results = function ($type, $dep) {
@@ -174,7 +174,7 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -274,7 +274,7 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -282,7 +282,7 @@ EOT;
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyTheme = $this->getGit(false, ['with' => 'git@git.dxw.net:wordpress-themes/my-theme', 'return' => false], null);
+        $gitMyTheme = $this->getGit(false, ['with' => 'git@git.govpress.com:wordpress-themes/my-theme', 'return' => false], null);
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
 
         $dependencies = new \Dxw\Whippet\Dependencies\Installer(
@@ -310,7 +310,7 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -318,7 +318,7 @@ EOT;
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyTheme = $this->getGit(false, 'git@git.dxw.net:wordpress-themes/my-theme', ['with' => '27ba906', 'return' => false]);
+        $gitMyTheme = $this->getGit(false, 'git@git.govpress.com:wordpress-themes/my-theme', ['with' => '27ba906', 'return' => false]);
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
 
         $dependencies = new \Dxw\Whippet\Dependencies\Installer(
@@ -372,19 +372,19 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
             'plugins' => [
                 [
                     'name' => 'my-plugin',
-                    'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+                    'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
                     'revision' => '123456',
                 ],
                 [
                     'name' => 'another-plugin',
-                    'src' => 'git@git.dxw.net:wordpress-plugins/another-plugin',
+                    'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
                     'revision' => '789abc',
                 ],
             ],
@@ -433,26 +433,26 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
             'plugins' => [
                 [
                     'name' => 'my-plugin',
-                    'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+                    'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
                     'revision' => '123456',
                 ],
                 [
                     'name' => 'another-plugin',
-                    'src' => 'git@git.dxw.net:wordpress-plugins/another-plugin',
+                    'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
                     'revision' => '789abc',
                 ],
             ],
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyPlugin = $this->getGit(false, 'git@git.dxw.net:wordpress-plugins/my-plugin', '123456');
+        $gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456');
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
 
         $dependencies = new \Dxw\Whippet\Dependencies\Installer(
@@ -478,7 +478,7 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -486,7 +486,7 @@ EOT;
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyTheme = $this->getGit(false, ['with' => 'git@git.dxw.net:wordpress-themes/my-theme', 'return' => false], null);
+        $gitMyTheme = $this->getGit(false, ['with' => 'git@git.govpress.com:wordpress-themes/my-theme', 'return' => false], null);
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
 
         $dependencies = new \Dxw\Whippet\Dependencies\Installer(
@@ -514,7 +514,7 @@ EOT;
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -522,7 +522,7 @@ EOT;
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $gitMyTheme = $this->getGit(false, 'git@git.dxw.net:wordpress-themes/my-theme', ['with' => '27ba906', 'return' => false]);
+        $gitMyTheme = $this->getGit(false, 'git@git.govpress.com:wordpress-themes/my-theme', ['with' => '27ba906', 'return' => false]);
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
 
         $dependencies = new \Dxw\Whippet\Dependencies\Installer(

--- a/tests/dependencies/migration_test.php
+++ b/tests/dependencies/migration_test.php
@@ -22,7 +22,7 @@ class Dependencies_Migration_Test extends \PHPUnit\Framework\TestCase
         $dir = $this->getDir();
 
         file_put_contents($dir.'/plugins', implode("\n", [
-            'source = "git@git.dxw.net:wordpress-plugins/"',
+            'source = "git@git.govpress.com:wordpress-plugins/"',
             'twitget=',
             'acf-options-page=',
             'new-members-only=',
@@ -40,15 +40,15 @@ class Dependencies_Migration_Test extends \PHPUnit\Framework\TestCase
             'jw-player-plugin-for-wordpress=',
             'gravityforms=',
             'unconfirmed=',
-            'oauth2-server = ,git@git.dxw.net:dxw-wp-plugins/oauth2-server',
-            'network-approve-users = v1.1.1,git@git.dxw.net:dxw-wp-plugins/network-approve-users',
+            'oauth2-server = ,git@git.govpress.com:dxw-wp-plugins/oauth2-server',
+            'network-approve-users = v1.1.1,git@git.govpress.com:dxw-wp-plugins/network-approve-users',
         ]));
 
         $whippetJson = $this->getWhippetJsonExpectSavePath($dir.'/whippet.json');
 
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Files\\WhippetJson', [
             'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'plugins' => [
                 ['name' => 'twitget'],
@@ -70,18 +70,18 @@ class Dependencies_Migration_Test extends \PHPUnit\Framework\TestCase
                 ['name' => 'unconfirmed'],
                 [
                     'name' => 'oauth2-server',
-                    'src' => 'git@git.dxw.net:dxw-wp-plugins/oauth2-server',
+                    'src' => 'git@git.govpress.com:dxw-wp-plugins/oauth2-server',
                 ],
                 [
                     'name' => 'network-approve-users',
                     'ref' => 'v1.1.1',
-                    'src' => 'git@git.dxw.net:dxw-wp-plugins/network-approve-users',
+                    'src' => 'git@git.govpress.com:dxw-wp-plugins/network-approve-users',
                 ],
             ],
         ], $whippetJson);
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $migration = new \Dxw\Whippet\Dependencies\Migration(
             $this->getFactory(),
@@ -102,7 +102,7 @@ class Dependencies_Migration_Test extends \PHPUnit\Framework\TestCase
 
         file_put_contents($dir.'/plugins', implode("\n", [
             '#bad comment',
-            'source = "git@git.dxw.net:wordpress-plugins/"',
+            'source = "git@git.govpress.com:wordpress-plugins/"',
             'twitget=',
         ]));
 
@@ -140,7 +140,7 @@ class Dependencies_Migration_Test extends \PHPUnit\Framework\TestCase
         $output = ob_get_clean();
 
         $this->assertTrue($result->isErr());
-        $this->assertEquals("Source is empty. It should just specify a repo root:\n\n  source = 'git@git.dxw.net:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.", $result->getErr());
+        $this->assertEquals("Source is empty. It should just specify a repo root:\n\n  source = 'git@git.govpress.com:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.", $result->getErr());
         $this->assertEquals('', $output);
 
         $this->assertFalse(file_exists($dir.'/whippet.json'));
@@ -172,7 +172,7 @@ class Dependencies_Migration_Test extends \PHPUnit\Framework\TestCase
         touch($dir.'/whippet.json');
 
         file_put_contents($dir.'/plugins', implode("\n", [
-            'source = "git@git.dxw.net:wordpress-plugins/"',
+            'source = "git@git.govpress.com:wordpress-plugins/"',
             'twitget=',
         ]));
 

--- a/tests/dependencies/updater_test.php
+++ b/tests/dependencies/updater_test.php
@@ -68,8 +68,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -95,13 +95,13 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
-            ['plugins', 'my-plugin', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'd961c3d'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
+            ['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -123,7 +123,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -149,11 +149,11 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -175,7 +175,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -202,11 +202,11 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -227,7 +227,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -248,7 +248,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::err('oh no'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::err('oh no'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -270,7 +270,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -315,7 +315,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -333,11 +333,11 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'master', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'master', \Result\Result::ok('27ba906'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -386,8 +386,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -413,13 +413,13 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
-            ['plugins', 'my-plugin', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'd961c3d'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
+            ['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -441,7 +441,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -465,7 +465,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', [
             ['themes', []],
             ['plugins', [
@@ -474,8 +474,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         ]);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -516,8 +516,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -543,13 +543,13 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
-            ['plugins', 'my-plugin', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'd961c3d'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
+            ['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Files\\WhippetLock', [], $whippetLock);
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::err('file not found'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
@@ -571,7 +571,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -599,8 +599,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -665,7 +665,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         file_put_contents($dir.'/whippet.json', 'foobar');
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -705,7 +705,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -733,8 +733,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -757,7 +757,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -783,11 +783,11 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -809,7 +809,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -836,11 +836,11 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -861,7 +861,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -887,7 +887,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $whippetLock = $this->getWhippetLockWritable([], sha1('foobar'), null, []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::err('oh no'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::err('oh no'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -909,8 +909,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -963,7 +963,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
             ],
             'themes' => [
                 [
@@ -987,11 +987,11 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'master', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'master', \Result\Result::ok('27ba906'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -1012,8 +1012,8 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'themes' => 'git@git.dxw.net:wordpress-themes/',
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'themes' => 'git@git.govpress.com:wordpress-themes/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -1039,12 +1039,12 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Gitignore', $dir, $gitignore);
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['themes', 'my-theme', 'git@git.dxw.net:wordpress-themes/my-theme', '27ba906'],
+            ['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $dependencies = new \Dxw\Whippet\Dependencies\Updater(
             $this->getFactory(),
@@ -1067,7 +1067,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
         $whippetJson = $this->getWhippetJson([
             'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
             'themes' => [
                 [
@@ -1085,12 +1085,12 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
         $whippetLock = $this->getWhippetLockWritable([
-            ['plugins', 'my-plugin', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'd961c3d'],
+            ['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
         ], sha1('foobar'), $dir.'/whippet.lock', []);
 
         $this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.dxw.net:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+        $this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
         $gitignore = $this->getGitignore(["/wp-content/themes/my-theme\n",
         "/wp-content/plugins/my-plugin\n", ], [

--- a/tests/files/whippet_json_test.php
+++ b/tests/files/whippet_json_test.php
@@ -28,12 +28,12 @@ class Files_WhippetJson_Test extends \PHPUnit\Framework\TestCase
     {
         $whippetJson = new \Dxw\Whippet\Files\WhippetJson([
             'src' => [
-                'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+                'plugins' => 'git@git.govpress.com:wordpress-plugins/',
             ],
         ]);
 
         $this->assertEquals([
-            'plugins' => 'git@git.dxw.net:wordpress-plugins/',
+            'plugins' => 'git@git.govpress.com:wordpress-plugins/',
         ], $whippetJson->getSources());
     }
 

--- a/tests/files/whippet_lock_test.php
+++ b/tests/files/whippet_lock_test.php
@@ -10,7 +10,7 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -19,7 +19,7 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals([
             [
                 'name' => 'my-theme',
-                'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                 'revision' => '27ba906',
             ],
         ], $whippetLock->getDependencies('themes'));
@@ -31,7 +31,7 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -41,7 +41,7 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals([
             [
                 'name' => 'my-theme',
-                'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                 'revision' => '27ba906',
             ],
         ], $whippetLock->unwrap()->getDependencies('themes'));
@@ -55,7 +55,7 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
             'themes' => [
                 [
                     'name' => 'my-theme',
-                    'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                    'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                     'revision' => '27ba906',
                 ],
             ],
@@ -67,7 +67,7 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
         $this->assertEquals([
             [
                 'name' => 'my-theme',
-                'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+                'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
                 'revision' => '27ba906',
             ],
         ], $whippetLock->unwrap()->getDependencies('themes'));
@@ -104,11 +104,11 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
     {
         $whippetLock = new \Dxw\Whippet\Files\WhippetLock([]);
 
-        $whippetLock->addDependency('plugins', 'my-plugin', 'git@git.dxw.net:foobar/baz', '123abc');
+        $whippetLock->addDependency('plugins', 'my-plugin', 'git@git.govpress.com:foobar/baz', '123abc');
         $this->assertEquals([
             [
                 'name' => 'my-plugin',
-                'src' => 'git@git.dxw.net:foobar/baz',
+                'src' => 'git@git.govpress.com:foobar/baz',
                 'revision' => '123abc',
             ],
         ], $whippetLock->getDependencies('plugins'));
@@ -120,27 +120,27 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
             'plugins' => [
                 [
                     'name' => 'my-other-plugin',
-                    'src' => 'git@git.dxw.net:foobar/bat',
+                    'src' => 'git@git.govpress.com:foobar/bat',
                     'revision' => 'zzz',
                 ],
                 [
                     'name' => 'my-plugin',
-                    'src' => 'git@git.dxw.net:foobar/baz',
+                    'src' => 'git@git.govpress.com:foobar/baz',
                     'revision' => '456789',
                 ],
             ],
         ]);
 
-        $whippetLock->addDependency('plugins', 'my-plugin', 'git@git.dxw.net:foobar/baz', '123abc');
+        $whippetLock->addDependency('plugins', 'my-plugin', 'git@git.govpress.com:foobar/baz', '123abc');
         $this->assertEquals([
             [
                 'name' => 'my-other-plugin',
-                'src' => 'git@git.dxw.net:foobar/bat',
+                'src' => 'git@git.govpress.com:foobar/bat',
                 'revision' => 'zzz',
             ],
             [
                 'name' => 'my-plugin',
-                'src' => 'git@git.dxw.net:foobar/baz',
+                'src' => 'git@git.govpress.com:foobar/baz',
                 'revision' => '123abc',
             ],
         ], $whippetLock->getDependencies('plugins'));

--- a/tests/services/inspection_checker_test.php
+++ b/tests/services/inspection_checker_test.php
@@ -11,7 +11,7 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
     {
         $my_theme = [
             'name' => 'my-theme',
-            'src' => 'git@git.dxw.net:wordpress-themes/my-theme',
+            'src' => 'git@git.govpress.com:wordpress-themes/my-theme',
             'revision' => '27ba906',
         ];
         $checker = new \Dxw\Whippet\Services\InspectionChecker($this->fakeInspectionsApi());
@@ -31,7 +31,7 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
 
         $my_plugin = [
             'name' => 'my-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
             'revision' => '123456',
         ];
         $checker = new \Dxw\Whippet\Services\InspectionChecker($api);
@@ -46,7 +46,7 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
 
         $my_plugin = [
             'name' => 'my-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
             'revision' => '123456',
         ];
         $checker = new \Dxw\Whippet\Services\InspectionChecker($api);
@@ -75,7 +75,7 @@ EOT;
 
         $my_plugin = [
             'name' => 'my-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
             'revision' => '123456',
         ];
         $checker = new \Dxw\Whippet\Services\InspectionChecker($api);
@@ -103,7 +103,7 @@ EOT;
 
         $my_plugin = [
             'name' => 'my-plugin',
-            'src' => 'git@git.dxw.net:wordpress-plugins/my-plugin',
+            'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
             'revision' => '123456',
         ];
         $checker = new \Dxw\Whippet\Services\InspectionChecker($api);


### PR DESCRIPTION
We are deprecating the use of git.dxw.net and replacing it with
git.govpress.com.