### PR TITLE
Feature/add wordpress repository option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Repository option for app generation, so that application.json does not need to be manually edited after generating a new app
+
 ## [1.0.0] - 2020-01-17
 
 ### Changed

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -14,7 +14,7 @@ This will create a new Whippet application in `./whippet-app`. The structure of 
 
 You can change the location with the `-d` option.
 
-You can change the location of the WordPress repository set in `config/application.json` with the `-r` option.
+You can change the location of the WordPress core repository set in `config/application.json` with the `-r` option. The default is `https://github.com/WordPress/WordPress.git`.
 
 If you're using GitLab (e.g. within dxw infrastructure), use the `-c` option to generate a `.gitlab-ci.yml` template file for the app.
 
@@ -24,20 +24,20 @@ There are a few configuration steps you'll need to follow when you create a new 
 
 #### Set your WordPress version
 
-By default, Whippet uses the current development version of WordPress. To specify a version to develop against, you'll need to edit `config/application.json`:
+By default, Whippet uses the latest release of WordPress. To specify a version to develop against, you'll need to edit `config/application.json`:
 
 ```
 {
     "wordpress": {
         "repository": "https://github.com/WordPress/WordPress.git",
-        "revision": "master"
+        "revision": "5.4.2"
     }
 }
 ```
 
 You can also change the WordPress repository used here by setting the `-r` option when generating a new Whippet application.
 
-To change the version, replace "master" with the version you'd like:
+To change the version, replace the "revision" value with the version you'd like:
 
 ```
         "revision": "4.1.1"

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -14,6 +14,8 @@ This will create a new Whippet application in `./whippet-app`. The structure of 
 
 You can change the location with the `-d` option.
 
+You can change the location of the WordPress repository set in `config/application.json` with the `-r` option.
+
 If you're using GitLab (e.g. within dxw infrastructure), use the `-c` option to generate a `.gitlab-ci.yml` template file for the app.
 
 ### Configure your application
@@ -32,6 +34,8 @@ By default, Whippet uses the current development version of WordPress. To specif
     }
 }
 ```
+
+You can also change the WordPress repository used here by setting the `-r` option when generating a new Whippet application.
 
 To change the version, replace "master" with the version you'd like:
 

--- a/generators/app/generate.php
+++ b/generators/app/generate.php
@@ -31,7 +31,19 @@ class AppGenerator extends \Dxw\Whippet\WhippetGenerator {
         $this->recurse_rm($this->target_dir . '/.gitlab-ci.yml');
     }
 
+    if(isset($this->options->repository)) {
+      $this->setWPRepository();
+    }
+
     $this->setWpVersion();
+   }
+
+   private function setWpRepository()
+   {
+      $appConfig = $this->target_dir . '/config/application.json';
+      $data = json_decode(file_get_contents($appConfig), JSON_OBJECT_AS_ARRAY);
+      $data['wordpress']['repository'] = $this->options->repository;
+      file_put_contents($appConfig, json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)."\n");
    }
 
    private function setWpVersion()

--- a/src/Whippet.php
+++ b/src/Whippet.php
@@ -18,10 +18,12 @@ class Whippet extends \RubbishThorClone
             $option_parser->addRule('l|list', 'Lists available generators');
             $option_parser->addRule('d|directory::', "Override the generator's default creation directory with this one");
             $option_parser->addRule('c|ci', 'When generating an app, adds a .gitlab-ci.yml template file');
+            $option_parser->addRule('r|repository::', 'When generating an app, override the default application.json WordPress repository with this one');
         });
 
         $this->command('init [PATH]', 'Creates a new Whippet application at PATH. NB: this is a shortcut for whippet generate -d PATH whippet.', function ($option_parser) {
             $option_parser->addRule('c|ci', 'Adds a .gitlab-ci.yml template file');
+            $option_parser->addRule('r|repository::', 'Override the default application.json WordPress repository with this one');
         });
 
         $this->command('migrate OLDPATH NEWPATH', 'Examines an existing wp-content directory and attempts to create an identical Whippet application.');


### PR DESCRIPTION
This PR adds the option to override the default WordPress repo value set in `config/application.json` when generating a new app by doing `whippet generate app -r=[the-alternative-git-repo-for-wp-core]`.

We're probably going to be generating quite a lot of Whippet apps as part of the Helpful migration, so this will save us having to manually edit that file each time.

- [x] Changelog updated
