### PR TITLE
Update pull request template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,6 +1,5 @@
 Resolves: https://...
 
-- [ ] Version number has been incremented, according to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) rules
 - [ ] Includes tests (if new features are introduced)
 - [ ] Commit message includes link to the ticket/issue
 - [ ] Changelog updated


### PR DESCRIPTION
Version number doesn't exist in the tree - it can only be assigned
later via tagging a commit.