### PR TITLE
Use Wordpress-template repo as source for theme generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The [WordPress template repo](https://github.com/dxw/wordpress-template) is used as the source when generating a new app
+- The [WordPress template repo](https://github.com/dxw/wordpress-template) is used as the source when generating a new theme
 
 ### Removed
 - The `-c` option when generating an app to include a `gitlab-ci.yml` file is removed, as this does not exist in the new WordPress template repo.
+- `whippet generate theme` no longer does auto-namespacing based on directory name, because the default namespace is always just `Theme/`.
 
 ## [1.0.1] - 2020-02-14
 - Use stable version of rubbishthorclone


### PR DESCRIPTION
Before: `whippet generate theme` used the Whippet Theme Template repo as the source for the generated theme. That repo is being replaced by the WordPress Template, which includes a theme within it

Now: `whippet generate theme` uses the theme from the WordPress Template as its source.

Note, because the new repo uses `Theme/` as the namespace for the theme, this means the auto-replacement of namespacing that whippet theme generation used to do is no longer possible.

Resolves: https://github.com/dxw/whippet/issues/151

- [x] Commit message includes link to the ticket/issue
- [x] Changelog updated
