### PR TITLE
Fix/use root gitignore for theme generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2021-04-06
+
+### Added
+- A `-nogitignore` option when generating a theme, that generates a theme without an accompanying `.gitignore` file
+
+### Changed
+- The [WordPress template repo's](https://github.com/dxw/wordpress-template) root `.gitignore` file is used by default when generating a theme
+
 ## [2.0.0] - 2020-12-09
 
 ### Added

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -42,6 +42,10 @@ class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
   private function copyThemeAndRemoveTemplate()
   {   
     $this->recurse_copy('/tmp/wordpress_template_' . $this->unique_temp_id . '/wordpress-template-main/wp-content/themes/theme', $this->target_dir);
+    copy('/tmp/wordpress_template_' . $this->unique_temp_id . '/wordpress-template-main/.gitignore', $this->target_dir . '/.gitignore');
+    if(isset($this->options->nogitignore)) {
+      unlink($this->target_dir . '/.gitignore');
+    }   
     $this->recurse_rm('/tmp/wordpress_template_' . $this->unique_temp_id);
   }
 };

--- a/src/Whippet.php
+++ b/src/Whippet.php
@@ -17,6 +17,7 @@ class Whippet extends \RubbishThorClone
         $this->command('generate [THING]', 'Generates a thing', function ($option_parser) {
             $option_parser->addRule('l|list', 'Lists available generators');
             $option_parser->addRule('d|directory::', "Override the generator's default creation directory with this one");
+            $option_parser->addRule('n|nogitignore', 'When generating a theme, do not generate the accompanying .gitignore file');
             $option_parser->addRule('r|repository::', 'When generating an app, override the default application.json WordPress repository with this one');
         });
 


### PR DESCRIPTION
In https://github.com/dxw/wordpress-template/pull/56, we updating the WordPress Template repo to use a single `.gitignore`, in the repo's root. For Whippet's previous behaviour, this would have meant that `whippet generate theme` would have generated a theme with no `.gitignore`.

Therefore this PR:

* Updates the default behaviour of `whippet generate theme`, so that it copies the template's root `.gitignore` into the generated theme
* Adds a `-nogitignore` options to `whippet generate theme`, so it's possible to generate a theme without a `.gitignore` if, for instance, that theme will live within a repo that already has a comprehensive `.gitignore` in its root
* Bumps the version to 2.1.0

- [x] Changelog updated
- [x] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 

Draft PR against Homebrew Tap: https://github.com/dxw/homebrew-tap/pull/6
