### PR TITLE
Release/version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2021-09-30
 
 ### Added
 

--- a/docs/themesandplugins.md
+++ b/docs/themesandplugins.md
@@ -101,6 +101,16 @@ This will:
 
 This command will run through the items in `whippet.lock` and clone any missing plugins/themes, or fetch and checkout.
 
+### whippet deps validate
+
+Will check that `whippet.json` and `whippet.lock` are well-formed and aligned with one another, i.e.:
+
+1. Both files are valid JSON
+1. The hash in `whippet.lock` is as expected from the contents of `whippet.json`
+1. There are the same number of dependencies listed in each file
+1. Each dependency in `whippet.json` has a corresponding entry in `whippet.lock`
+1. Each dependency in `whippet.lock` is well-formed, with a name, src and revision
+
 ## Checking for inspections
 
 Both the `install` and `update` commands will both attempt to check that a


### PR DESCRIPTION
Updates to v2.2.0 for a release including `whippet deps validate` command.

Draft dxw Homebrew Tap PR: https://github.com/dxw/homebrew-tap/pull/7

- [x] Changelog updated
- [x] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
