### PR TITLE
v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2022-06-28
+### Changed
+- Update `guzzlehttp/guzzle` to patch authorization vulnerabilities in versions < 6.5.8.
+
 ## [2.2.2] - 2022-05-30
 ### Changed
 - Update `guzzlehttp/guzzle` to patch a cookie-related vulnerability. This vulnerability does not affect us directly, so just updating as a precaution.


### PR DESCRIPTION
Patches a `guzzlehttp/guzzle` vulnerability.

- [x] Changelog updated
- [x] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number: https://github.com/dxw/homebrew-tap/pull/14
