### PR TITLE
Fix/deprecated implode warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `whippet deps describe` command, that provides a JSON report on the version tags associated with the commit hashes in `whippet.lock`
 ### Changed
+- FIXed deprecation warning in deploy module
 - Update security.dxw.com to advisories.dxw.com
 - Added setup and test scripts following the "scripts to rule them all pattern".
 ### Removed

--- a/src/Modules/Deploy.php
+++ b/src/Modules/Deploy.php
@@ -111,7 +111,7 @@ class Deploy
 				rename("{$new_release->release_dir}", "{$broken_release}");
 
 				echo "Problems:\n";
-				echo implode($messages, "\n");
+				echo implode("\n", $messages);
 				echo "\n\nRelease did not validate; it has been moved to: $broken_release";
 
 				exit(1);


### PR DESCRIPTION
This should probably be merged just before #179

@RobjS other than bringing #179 up to date with the latest changes in the default branch, are we OK to merge that one?

Note, this is blocking a deploy: https://dxw.slack.com/archives/C04AJM8DCRF/p1692799868742929?thread_ts=1692799755.245969&cid=C04AJM8DCRF

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
