### PR TITLE
whippet deploy can optionally deploy public dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.0] - 2023-06-14
 ### Added
 - `whippet deps describe` command, that provides a JSON report on the version tags associated with the commit hashes in `whippet.lock`
+- Add --public switch to deploy cmd to deploy public/ directory separately to the WP app.
 ### Changed
 - FIXed deprecation warning in deploy module
 - Update security.dxw.com to advisories.dxw.com

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -34,3 +34,22 @@ Note also that Whippet, by default, will not deploy your application if the comm
 ```
 $ whippet deploy -f /var/local/myapp
 ```
+
+### Deploying the `public/` directory
+
+By default, the `public/` directory inside a WordPress app will be copied into
+the app directory on deploy.
+
+By passing in the `-p` or `--public` argument, files in `public/` will be deployed
+to a given directory, e.g.:
+
+```
+$ whippet deploy -p /path/to/public
+```
+
+will copy the contents of `public/` to `/path/to/public`, rather than copying
+them into `/var/local/myapp/current/`.
+
+However, if `whippet deploy` is run _after_ `whippet deploy -p <directory>`, the second
+deployment will not remove the files in `public/` that were deployed by the
+first deployment.

--- a/src/Modules/Deploy.php
+++ b/src/Modules/Deploy.php
@@ -11,9 +11,10 @@ class Deploy
 		$this->deploy_dir = $dir;
 		$this->releases_dir = "{$this->deploy_dir}/releases";
 		$this->shared_dir = "{$this->deploy_dir}/shared";
+		$this->public_dir = "";
 	}
 
-	public function deploy($force, $keep)
+	public function deploy($force, $keep, $public)
 	{
 		try {
 			//
@@ -33,6 +34,10 @@ class Deploy
 			$this->check_and_create_dir($this->deploy_dir);
 			$this->check_and_create_dir($this->releases_dir);
 			$this->check_and_create_dir($this->shared_dir);
+			if (!empty($public)) {
+				$this->public_dir = $public;
+				$this->check_and_create_dir($this->public_dir);
+			}
 
 			//
 			// Load up the manifest and create the new release
@@ -47,10 +52,10 @@ class Deploy
 				$release_number = 0;
 			}
 
-			$new_release = new Release($this->releases_dir, '', $release_number);
+			$new_release = new Release($this->releases_dir, '', $release_number, $this->public_dir);
 
 			// Make it.
-			$new_release->create($force);
+			$new_release->create($force, $public);
 
 			//
 			// Did everything work?
@@ -192,22 +197,3 @@ class Deploy
 		return file_put_contents("{$this->deploy_dir}/releases/manifest.json", json_encode($this->releases_manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 	}
 };
-
-/*
-/var/data/dxw.com     # app repo
-
-app
-releases
-c1cbf7b2f8ecd7d6befece09f712c85a7c839b      # a working WP deploy
-shared
-wp-config.php
-uploads -> /somewhere/that/uploads/exist
-current -> c1cbf7b2f8ecd7d6befece09f712c85a7c839b
-
-/var/vhosts/dxw.com -> /app/current
-
-
-
-git pull
-whippet deploy /path/to/app
-*/

--- a/src/Modules/Release.php
+++ b/src/Modules/Release.php
@@ -10,7 +10,7 @@ class Release
 	public $number = 0;
 	public $time = 0;
 
-	public function __construct($releases_dir, $message, $number)
+	public function __construct($releases_dir, $message, $number, $public_dir)
 	{
 		$this->whippet_init();
 		$this->load_plugins_lock();
@@ -21,9 +21,10 @@ class Release
 		$this->time = date('r');
 		$this->deployed_commit = $git->current_commit();
 		$this->release_dir = "{$releases_dir}/{$this->deployed_commit}";
+		$this->public_dir = $public_dir;
 	}
 
-	public function create(&$force)
+	public function create(&$force, &$deploy_public)
 	{
 		//
 		// Does this commit have a release directory already? If so, do nothing
@@ -125,10 +126,11 @@ class Release
 		}
 
 		//
-		// Copy public assets
+		// Deploy public assets or copy them into the app directory
 		//
 		if (is_dir("{$this->project_dir}/public")) {
-			$this->recurse_copy("{$this->project_dir}/public", "{$this->release_dir}");
+			$public_dest = $deploy_public ? $this->public_dir : $this->release_dir;
+			$this->recurse_copy("{$this->project_dir}/public", "{$public_dest}");
 		}
 
 		//

--- a/src/Whippet.php
+++ b/src/Whippet.php
@@ -12,6 +12,7 @@ class Whippet extends \RubbishThorClone
 		$this->command('deploy DIR', "Generates a working WordPress installation in DIR, based on the current contents of your app's repository", function ($option_parser) {
 			$option_parser->addRule('f|force', 'Force Whippet to deploy, even if a release already exists for this commit');
 			$option_parser->addRule('k|keep::', 'Tells Whippet how many old release directories to keep. Default: 3');
+			$option_parser->addRule('p|public::', 'Deploy public/ in a given directory, adjacent to the app');
 		});
 
 		$this->command('generate [THING]', 'Generates a thing', function ($option_parser) {
@@ -46,7 +47,15 @@ class Whippet extends \RubbishThorClone
 			$this->options->keep = 3;
 		}
 
-		(new Modules\Deploy($dir))->deploy(isset($this->options->force), $this->options->keep);
+		if (!isset($this->options->public)) {
+			$this->options->public = "";
+		}
+
+		(new Modules\Deploy($dir))->deploy(
+			isset($this->options->force),
+			$this->options->keep,
+			$this->options->public
+		);
 	}
 
 	public function init($path = false)


### PR DESCRIPTION
Before: any files in the `public/` directory inside the WordPress app were copied (recursively) into the app directory on deploy.

Now: by passing in the `-p (--public) <directory>` switch to 'whippet deploy' the `public/` directory can be deployed to the given destination directory.

Resolves: #196

## Testing locally

1. Move somewhere where you don't mind splatting a lot of files, e.g. `cd /tmp`
2. Clone any Whippetised repo, e.g. `git clone git@github.com:dxw/saluki-test-site.git`
3. Create deployment directories, e.g. `mkdir -r /tmp/whippet-deploy/shared/uploads`
4. Add a basic `wp-config.php` file to your `shared/` directory, e.g.:
```php
define( 'DB_NAME', 'test_tb' );
define( 'DB_USER', 'db_user' );
define( 'DB_PASSWORD', 'db_passwd' );
define( 'DB_HOST', 'localhost' );
```
5. Ensure that you have this branch of Whippet checked out
6. From the root of your cloned Wordpress repo, run some test deploys, e.g. ` /path/to/whippet/bin/whippet deploy -f /tmp/whippet-deploy -p /tmp/random-directory`
7. Check that `/tmp/random-directory` contains the files you can see in `public/`

----

- [ ] Includes tests (if new features are introduced)
- [x] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
