### PR TITLE
Feature/whippet deps describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `whippet deps describe` command, that provides a JSON report on the version tags associated with the commit hashes in `whippet.lock`
+### Changed
 - Update security.dxw.com to advisories.dxw.com
 - Added setup and test scripts following the "scripts to rule them all pattern".
 

--- a/script/test
+++ b/script/test
@@ -27,5 +27,5 @@ else
 	./vendor/bin/php-cs-fixer fix --dry-run -v --diff
 
 	echo "==> Running the tests..."
-	./vendor/bin/phpunit
+	./vendor/bin/phpunit && ./vendor/bin/kahlan spec
 fi

--- a/spec/dependencies/describer.spec.php
+++ b/spec/dependencies/describer.spec.php
@@ -1,0 +1,101 @@
+<?php
+
+use Kahlan\Plugin\Double;
+
+describe(Dxw\Whippet\Dependencies\Describer::class, function () {
+    beforeEach(function () {
+        $this->factory = Double::instance(['extends' => '\Dxw\Whippet\Factory']);
+        $this->projectDirectory = Double::instance([
+            'extends' => 'Dxw\Whippet\ProjectDirectory',
+            'magicMethods' => true
+        ]);
+        $this->describer = new \Dxw\Whippet\Dependencies\Describer(
+            $this->factory,
+            $this->projectDirectory
+        );
+    });
+
+    describe('->describe()', function () {
+        context('whippet.lock file not loaded successfully', function () {
+            it('returns an error result', function () {
+                allow($this->factory)->toReceive('callStatic')->andReturn(\Result\Result::err('Error loading whippet.lock'));
+                
+                $result = $this->describer->describe();
+                
+                expect($result->isErr())->toEqual(true);
+                expect($result->getErr())->toEqual('Error loading whippet.lock');
+            });
+        });
+
+        context('Error getting the references for one of the git repos', function () {
+            it('returns an error result', function () {
+                $whippetLock = Double::instance([
+                    'extends' => '\Dxw\Whippet\Files\WhippetLock',
+                    'magicMethods' => true
+                ]);
+                allow($whippetLock)->toReceive('getDependencies')->andReturn([
+                    [
+                        'name' => 'plugin-one',
+                        'src' => 'plugin-one-src',
+                        'revision' => 'commit-hash'
+                    ]
+                ]);
+                allow($this->factory)->toReceive('callStatic')->andReturn(\Result\Result::ok($whippetLock));
+                $git = Double::instance([
+                    'extends' => '\Dxw\Whippet\Git\Git',
+                    'magicMethods' => true
+                ]);
+                allow(\Dxw\Whippet\Git\Git::class)->toBe($git);
+                allow($git)->toReceive('::tag_for_commit')->andReturn(\Result\Result::err('Error getting tag'));
+                
+                $result = $this->describer->describe();
+                
+                expect($result->isErr())->toEqual(true);
+                expect($result->getErr())->toEqual('Error getting tag');
+            });
+        });
+
+        it('outputs a JSON report and returns an OK result', function () {
+            $whippetLock = Double::instance([
+                'extends' => '\Dxw\Whippet\Files\WhippetLock',
+                'magicMethods' => true
+            ]);
+            allow($whippetLock)->toReceive('getDependencies')->andReturn([
+                [
+                    'name' => 'theme-one',
+                    'src' => 'theme-one-src',
+                    'revision' => 'commit-hash'
+                ]
+            ], [
+                [
+                    'name' => 'plugin-one',
+                    'src' => 'plugin-one-src',
+                    'revision' => 'commit-hash'
+                ],
+            ]);
+            allow($this->factory)->toReceive('callStatic')->andReturn(\Result\Result::ok($whippetLock));
+            $git = Double::instance([
+                'extends' => '\Dxw\Whippet\Git\Git',
+                'magicMethods' => true
+            ]);
+            allow(\Dxw\Whippet\Git\Git::class)->toBe($git);
+            allow($git)->toReceive('::tag_for_commit')->andReturn(\Result\Result::ok('v1.0.1'), \Result\Result::ok('v3.0'));
+
+            ob_start();
+
+            $result = $this->describer->describe();
+
+            $output = ob_get_clean();
+
+            expect(json_decode($output, null, 5, JSON_OBJECT_AS_ARRAY))->toEqual([
+                'themes' => [
+                    'theme-one' => 'v1.0.1'
+                ],
+                'plugins' => [
+                    'plugin-one' => 'v3.0'
+                ]
+            ]);
+            expect($result->isErr())->toBe(false);
+        });
+    });
+});

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Dxw\Whippet\Dependencies;
+
+class Describer
+{
+    private $lockFile;
+    private $dir;
+    private $factory;
+
+    public function __construct(
+        \Dxw\Whippet\Factory $factory,
+        \Dxw\Whippet\ProjectDirectory $dir
+    ) {
+        $this->factory = $factory;
+        $this->dir = $dir;
+    }
+
+    public function describe()
+    {
+        $resultLoad = $this->loadWhippetLock();
+        if ($resultLoad->isErr()) {
+            return $resultLoad;
+        }
+        $dependencyTypes = ['themes', 'plugins'];
+        $git = new \Dxw\Whippet\Git\Git($this->dir);
+        $results = [];
+        foreach ($dependencyTypes as $type) {
+            foreach ($this->lockFile->getDependencies($type) as $dep) {
+                $result = $git::tag_for_commit($dep['src'], $dep['revision']);
+                if ($result->isErr()) {
+                    return $result;
+                }
+                $results[$type][$dep["name"]] = $result->unwrap();
+            }
+        }
+        $pretty_results = json_encode($results, JSON_PRETTY_PRINT);
+        printf($pretty_results);
+
+        return \Result\Result::ok();
+    }
+
+    private function loadWhippetLock()
+    {
+        $result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $this->dir.'/whippet.lock');
+        if ($result->isErr()) {
+            return $result;
+        } else {
+            $this->lockFile = $result->unwrap();
+        }
+
+        return \Result\Result::ok();
+    }
+}

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -374,7 +374,7 @@ class Git
         }
 
         $resultArray = explode('/', $tags_array[0]);
-        $result = end($resultArray);
+        $result = str_replace("^{}", "", end($resultArray));
 
         return \Result\Result::ok($result);
     }

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -352,4 +352,30 @@ class Git
 
         return \Result\Result::ok(explode("\t", $output[0])[0]);
     }
+
+    public static function tag_for_commit($repo, $commit_hash)
+    {
+        exec(sprintf('git ls-remote %s', escapeshellarg($repo)), $output, $return);
+
+        if ($return !== 0) {
+            return \Result\Result::err('git error when attempting to access ' . $repo);
+        }
+
+        if (count($output) === 0) {
+            return \Result\Result::err('no references found for repo ' . $repo);
+        }
+
+        $tags_array = array_values(array_filter($output, function ($ref) use ($commit_hash) {
+            return strpos($ref, $commit_hash) === 0 && strpos($ref, 'refs/tags') !== false;
+        }));
+
+        if (empty($tags_array)) {
+            return \Result\Result::ok('No tags for commit ' . $commit_hash);
+        }
+
+        $resultArray = explode('/', $tags_array[0]);
+        $result = end($resultArray);
+
+        return \Result\Result::ok($result);
+    }
 };

--- a/src/Modules/Dependencies.php
+++ b/src/Modules/Dependencies.php
@@ -30,6 +30,7 @@ class Dependencies extends \RubbishThorClone
         $this->command('update', 'Updates dependencies to their latest versions. Use deps update [type]/[name] to update a specific dependency', $inspections_host_option);
         $this->command('migrate', 'Converts legacy plugins file to whippet.json');
         $this->command('validate', 'Validate whippet.json and whippet.lock files');
+        $this->command('describe', 'List dependencies and their versions');
     }
 
     private function exitIfError(\Result\Result $result)
@@ -82,6 +83,13 @@ class Dependencies extends \RubbishThorClone
         $dir = $this->getDirectory();
         $validator = new \Dxw\Whippet\Dependencies\Validator($this->factory, $dir);
         $this->exitIfError(($validator->validate()));
+    }
+
+    public function describe()
+    {
+        $dir = $this->getDirectory();
+        $describer = new \Dxw\Whippet\Dependencies\Describer($this->factory, $dir);
+        $this->exitIfError(($describer->describe()));
     }
 
     private function inspectionChecker()


### PR DESCRIPTION
This PR introduces a new command, `whippet deps describe`, which outputs a JSON report on the dependencies specified in `whippet.lock`, and the version tags (if any) that the commit hashes currently locked at correspond to. It uses `git ls-remote` to do this, and therefore doesn't require either a) installation of the dependencies, or b) access via the GitHub API; it just needs the developer running the command to have read access to the dependency repos (which is implicit in all uses of Whippet).

Where no tag info is found for a specific commit hash, that is reported. e.g. the output for the current `develop` branch of Bikeshed is:

```
{
    "themes": {
        "govpress-product-theme": "No tags for commit 6be16f83da45b189e9dbcbd36745219460ffec96"
    },
    "plugins": {
        "classic-editor": "v1.6.3",
        "co-authors-plus": "v3.5.10",
        "dxw-members-only": "No tags for commit 2633c3d9f73e16352c0310097ed057e989fd5f2c",
        "slack": "v0.6.0",
        "notify-users-e-mail": "v4.1.3",
        "parsedown-party": "v1.2.1",
        "advanced-custom-fields-pro": "v6.1.6"
    }
}
```

While this could be useful locally to a developer (as it'd give them a quick summary of the versions installed, which otherwise they'd have to spin up the site and check the WordPress backend for), it's primary use is intended to be in automated workflows, where this command will be able to give us a human-readable summary of changes made to `whippet.lock` in PRs, probably via comments automatically added to the PRs. In future, this could potentially be extended so the workflow understands whether there have been any major version bumps, and changes its behaviour on that basis (e.g. by allowing PRs that only contain edits to `whippet.lock`, and don't introduce major version bumps, to auto-merge).

## How to test

1. If you've installed Whippet from source, you should just need to pull and checkout this branch. If not, you may want to alias a source version of whippet to your local copy of this repo, e.g. by doing `alias whippet-test="$PWD/bin/whippet"` from inside the repo directory.
2. Run `whippet deps describe` (or `whippet-test deps describe` if your standard `whippet` isn't installed from source) from within a Whippet app, and it should output a JSON report of the dependencies and their versions.


- [x] Includes tests (if new features are introduced)
- [x] Changelog updated
