### PR TITLE
Add a plugin generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for PHP 8
+- `whippet generate plugin` to generate a plugin based on our template repo https://github.com/dxw/wordpress-plugin-template/
 
 ### Removed
 - `whippet migrate` commands.

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -84,3 +84,17 @@ This will generate a new Whippet-compliant WordPress theme in `./whippet-theme`.
 You can change the location with the `-d` option.
 
 The generated theme is based on the theme in the [dxw WordPress template](https://github.com/dxw/wordpress-template/).
+
+## Generating a Whippet plugin
+
+To create a new Whippet plugin, run:
+
+```
+$ whippet generate plugin
+```
+
+This will generate a new Whippet-compliant WordPress plugin in `./whippet-plugin`.
+
+You can change the location with the `-d` option.
+
+The generated plugin is based on code in the [dxw WordPress plugin template](https://github.com/dxw/wordpress-plugin-template/).

--- a/generators/app/generate.php
+++ b/generators/app/generate.php
@@ -4,6 +4,8 @@ class AppGenerator extends \Dxw\Whippet\WhippetGenerator {
   use \Dxw\Whippet\Modules\Helpers\WhippetHelpers;
 
   protected $wordpress_template_zip = 'https://github.com/dxw/wordpress-template/archive/main.zip';
+  private $target_dir;
+  private $options = array();
 
   function __construct($options) {
     $this->options = $options;

--- a/generators/plugin/generate.php
+++ b/generators/plugin/generate.php
@@ -8,6 +8,8 @@ class PluginGenerator extends \Dxw\Whippet\WhippetGenerator {
   protected $plugin_template_zip = 'https://github.com/dxw/wordpress-plugin-template/archive/main.zip';
 
   private $unique_temp_id;
+  private $target_dir;
+  private $options = array();
 
   function __construct($options) {
     $this->options = $options;

--- a/generators/plugin/generate.php
+++ b/generators/plugin/generate.php
@@ -1,0 +1,51 @@
+<?php
+
+use Dxw\Whippet\Git\Git;
+
+class PluginGenerator extends \Dxw\Whippet\WhippetGenerator {
+  use \Dxw\Whippet\Modules\Helpers\WhippetHelpers;
+
+  protected $plugin_template_zip = 'https://github.com/dxw/wordpress-plugin-template/archive/main.zip';
+
+  private $unique_temp_id;
+
+  function __construct($options) {
+    $this->options = $options;
+
+    if(isset($this->options->directory)) {
+      $this->target_dir = getcwd() . '/' . $this->options->directory;
+    }
+    else {
+      $this->target_dir = getcwd() . "/whippet-plugin";
+    }
+
+    $this->unique_temp_id = uniqid();
+  }
+
+  function generate() {
+    echo "Creating a new whippet plugin in {$this->target_dir}\n";
+
+    if(!file_exists($this->target_dir)) {
+      mkdir($this->target_dir);
+    }
+
+    $this->downloadAndUnzipTemplate();
+    $this->copyThemeAndRemoveTemplate();
+  }
+
+  private function downloadAndUnzipTemplate()
+  {
+    $this->download_url_to_file($this->plugin_template_zip, '/tmp/plugin_template_' . $this->unique_temp_id . '.zip');
+    $this->unzip_to_folder('/tmp/plugin_template_' . $this->unique_temp_id . '.zip', '/tmp/plugin_template_' . $this->unique_temp_id);
+  }
+
+  private function copyThemeAndRemoveTemplate()
+  {
+    $this->recurse_copy('/tmp/plugin_template_' . $this->unique_temp_id . '/wordpress-plugin-template-main', $this->target_dir);
+    copy('/tmp/plugin_template_' . $this->unique_temp_id . '/wordpress-plugin-template-main/.gitignore', $this->target_dir . '/.gitignore');
+    if(isset($this->options->nogitignore)) {
+      unlink($this->target_dir . '/.gitignore');
+    }
+    $this->recurse_rm('/tmp/plugin_template_' . $this->unique_temp_id);
+  }
+};

--- a/generators/theme/generate.php
+++ b/generators/theme/generate.php
@@ -8,6 +8,8 @@ class ThemeGenerator extends \Dxw\Whippet\WhippetGenerator {
   protected $wordpress_template_zip = 'https://github.com/dxw/wordpress-template/archive/main.zip';
 
   private $unique_temp_id;
+  private $target_dir;
+  private $options = array();
 
   function __construct($options) {
     $this->options = $options;


### PR DESCRIPTION
Add a new generator to clone code in our WordPress plugin repo:

https://github.com/dxw/wordpress-plugin-template

Resolves: #162 

## Testing

Run `whippet generate plugin` and maybe try the relevant options, e.g. `--nogitignore`

----

- [ ] Includes tests (if new features are introduced)
- [x] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
