### PR TITLE
Generated app can be deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `whippet generate app` generates an app which can be deployed by Whippet.
+
 ### Added
 - Support for PHP 8
 - `whippet generate plugin` to generate a plugin based on our template repo https://github.com/dxw/wordpress-plugin-template/

--- a/generators/app/generate.php
+++ b/generators/app/generate.php
@@ -42,8 +42,6 @@ class AppGenerator extends \Dxw\Whippet\WhippetGenerator {
       $this->setWPRepository();
     }
 
-    $this->setWpVersion();
-
     /* zip archives don't preserve permissions, so fix those */
     exec("chmod 0755 " . $this->target_dir . "/setup/*");
     exec("chmod 0755 " . $this->target_dir . "/script/*");
@@ -63,14 +61,6 @@ class AppGenerator extends \Dxw\Whippet\WhippetGenerator {
     $appConfig = $this->target_dir . '/config/application.json';
     $data = json_decode(file_get_contents($appConfig), JSON_OBJECT_AS_ARRAY);
     $data['wordpress']['repository'] = $this->options->repository;
-    file_put_contents($appConfig, json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)."\n");
-  }
-
-  private function setWpVersion()
-  {
-    $appConfig = $this->target_dir . '/config/application.json';
-    $data = json_decode(file_get_contents($appConfig), JSON_OBJECT_AS_ARRAY);
-    $data['wordpress']['revision'] = $this->getLatest();
     file_put_contents($appConfig, json_encode($data, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)."\n");
   }
 

--- a/generators/app/generate.php
+++ b/generators/app/generate.php
@@ -27,7 +27,8 @@ class AppGenerator extends \Dxw\Whippet\WhippetGenerator {
     }
 
     // Make the target dir a git repo, if it isn't already
-    if(!(new \Dxw\Whippet\Git\Git($this->target_dir))->is_repo()) {
+    $target_repo = new \Dxw\Whippet\Git\Git($this->target_dir);
+    if(!$target_repo->is_repo()) {
       \Dxw\Whippet\Git\Git::init($this->target_dir);
     }
 
@@ -47,6 +48,12 @@ class AppGenerator extends \Dxw\Whippet\WhippetGenerator {
     exec("chmod 0755 " . $this->target_dir . "/setup/*");
     exec("chmod 0755 " . $this->target_dir . "/script/*");
     exec("chmod 0755 " . $this->target_dir . "/bin/*");
+
+    // Whippet deploy requires at least one commit in the repo.
+    if (!$target_repo->current_commit()) {
+      $target_repo->add("--all");
+      $target_repo->commit("Initial commit from Whippet");
+    }
 
     echo "New whippet app successfully generated at {$this->target_dir} \n";
   }


### PR DESCRIPTION
Whippet expects that a deployable app is a Git repo, with at least one commit. Previously, an app generated by Whippet was a Git repo, but did not have any commits, and so could not be deployed.

This commit adds a single commit to generated apps, to fix that.

Fixes #47

### Testing

Follow the instructions in the issue on `main` branch first:

```shell
mkdir -p ~/www/issue_test/shared/uploads
touch ~/www/issue_test/shared/wp-config.php
whippet generate app
cd ./whippet-app
whippet plugins install
whippet deploy ~/www/issue_test
```

You should see an error similar to the one reported:

```shell
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Checkout failed:
...
```

Run the same set of commands in this feature branch. Expected result is that the deploy continues, and fails much later because `wp-config.php` is empty.

----

- [ ] Includes tests (if new features are introduced)
- [x] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
