### PR TITLE
Add dependency commands back to CLI

### DIFF
--- a/src/Whippet.php
+++ b/src/Whippet.php
@@ -25,6 +25,8 @@ class Whippet extends \RubbishThorClone
 		$this->command('init [PATH]', 'Creates a new Whippet application at PATH. NB: this is a shortcut for whippet generate -d PATH whippet.', function ($option_parser) {
 			$option_parser->addRule('r|repository::', 'Override the default application.json WordPress repository with this one');
 		});
+		$this->command('dependencies SUBCOMMAND', 'Manage dependencies (themes, plugins)');
+		$this->command('deps SUBCOMMAND', 'Alias for dependencies');
 	}
 
 	public function plugins($plugin_command)


### PR DESCRIPTION
In d6fb898 we removed old migration commands, and accidentally removed some commands we want to keep. This commit adds those commands back to the CLI.


- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [ ] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
