### PR TITLE
Manage language packs for all dependency types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for PHP 8
 - `whippet generate plugin` to generate a plugin based on our template repo https://github.com/dxw/wordpress-plugin-template/
 - Psalm compliance
+- Support for managing WordPress language packs as a dependency
 
 ### Removed
 - `whippet migrate` commands.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ sudo ln -s $PWD/bin/whippet /usr/local/bin/whippet
 
 The main things you can use Whippet to do are:
 
-* [Generating a Whippet application or theme](docs/generate.md)
-* [Managing themes and plugins](docs/themesandplugins.md)
+* [Generating a Whippet application, theme or plugin](docs/generate.md)
+* [Managing themes, plugins and language packs](docs/managing-dependencies.md)
 * [Deploying a Whippet application](docs/deploy.md)
 
 ## Support

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -6,7 +6,7 @@ Whippet can generate new Whippet-compliant applications and themes for you.
 
 To create a new Whippet application, run:
 
-```
+```shell
 $ whippet generate app
 ```
 
@@ -24,7 +24,7 @@ There are a few configuration steps you'll need to follow when you create a new 
 
 By default, Whippet uses the latest release of WordPress. To specify a version to develop against, you'll need to edit `config/application.json`:
 
-```
+```json
 {
     "wordpress": {
         "repository": "https://github.com/WordPress/WordPress.git",
@@ -37,7 +37,7 @@ You can also change the WordPress repository used here by setting the `-r` optio
 
 To change the version, replace the "revision" value with the version you'd like:
 
-```
+```json
         "revision": "4.1.1"
 ```
 
@@ -62,7 +62,7 @@ The recommended method for running a Whippet application is to use the [wpc](htt
 
 An application that uses Whippet must have the following directory structure, and must be a git repository:
 
-```
+```md
 - config      # Application configuration files
 - public      # Non-WordPress files that should be available via the web
 - wp-content  # Your application's wp-content directory
@@ -75,7 +75,7 @@ An application that uses Whippet must have the following directory structure, an
 
 To create a new Whippet theme, run:
 
-```
+```shell
 $ whippet generate theme
 ```
 
@@ -89,7 +89,7 @@ The generated theme is based on the theme in the [dxw WordPress template](https:
 
 To create a new Whippet plugin, run:
 
-```
+```shell
 $ whippet generate plugin
 ```
 

--- a/docs/managing-dependencies.md
+++ b/docs/managing-dependencies.md
@@ -1,16 +1,33 @@
-# Managing themes and plugins
+# Managing themes, plugins and language packs
 
 Note: At the moment, Whippet assumes it is running within dxw's infrastructure, and makes some assumptions accordingly. If you run into a problem where this may be the cause, please open an issue.
 
-To manage plugins and themes using Whippet, you make entries in the `whippet.json` file in the root of the application.
+To manage plugins, themes and language packs using Whippet, you make entries in the `whippet.json` file in the root of the application.
 
 The file should specify a source for plugins and themes. The source should be a base url for a git repo.
 
 If you are a dxw customer, the source will be `git@git.govpress.com:wordpress-plugins/`. If not, we suggest using `https://github.com/wp-plugins` for plugins.
 
-The rest of the file should specify plugins and themes that you want to install. Example:
+For language packs, Whippet will query `https://api.wordpress.org/translations/` and use the given URL for the
+version of the language pack that you need. For any language you wish to install, Whippet will install the
+relevant files for the themes and plugins in your `whippet.json` file, as well as the files for WordPress Core.
 
+Note that if you do not have a file called `config/application.json` with an entry such as:
+
+```json
+{
+    "wordpress": {
+        "repository": "git@git.govpress.com:wordpress/snapshot",
+        "revision": "6.2.2"
+    }
+}
 ```
+
+Whippet will assume that you are using the current latest stable version of WordPress.
+
+The rest of the file should specify plugins, themes and language packs that you want to install. Example:
+
+```shell
 {
     "src": {
         "plugins": "git@git.govpress.com:wordpress-plugins/",
@@ -23,19 +40,23 @@ The rest of the file should specify plugins and themes that you want to install.
         {"name": "twentyfourteen"},
         {"name": "twentysixteen"},
         {"name": "twentyten"}
+    ],
+    "languages": [
+        {"name": "en_GB"},
+        {"name": "ja"}
     ]
 }
 ```
 
 The `{"name": "akismet"}` instructs Whippet (on request) to install the most recent version of Akismet available in the repo. Whippet will determine a valid repo URL for the akismet plugin by appending the name to the source. In this example:
 
-```
+```shell
 git@git.govpress.com:wordpress-plugins/akismet
 ```
 
 You can also specify a particular label or branch that you want to use. Generally, this will either be master (the default) or a tag (for a specific version), but you can use any git reference. So you can do:
 
-```
+```shell
 {
     "name": "akismet",
     "ref": "v1.1"
@@ -48,7 +69,7 @@ Finally, you can also specify a repo for an individual plugin or theme explicitl
 
 - Pull version 3.0.0 from your own special repo:
 
-```
+```json
 {
     "name": "akismet",
     "ref": "v3.0.0",
@@ -58,7 +79,7 @@ Finally, you can also specify a repo for an individual plugin or theme explicitl
 
 - Or, pull master:
 
-```
+```json
 {
     "name": "akismet",
     "ref": "master",
@@ -68,7 +89,7 @@ Finally, you can also specify a repo for an individual plugin or theme explicitl
 
 - This works too:
 
-```
+```json
 {
     "name": "akismet",
     "src": "git@my-git-server.com:akismet"

--- a/docs/support.md
+++ b/docs/support.md
@@ -8,7 +8,7 @@ However, you may well need to use it as part of supporting WordPress sites we ho
 
 ## Common tasks 
 
-### Updating plugins & themes via Whippet 
+### Updating plugins, themes and language packs via Whippet
 
 Run `whippet deps update` in the directory that contains the `whippet.lock` file. 
 
@@ -31,6 +31,10 @@ Manually edit the `whippet.json` file to add an entry to the "plugins" section f
         {"name": "twentyfourteen"},
         {"name": "twentysixteen"},
         {"name": "twentyten"}
+    ],
+    "languages": [
+        {"name": "en_GB"},
+        {"name": "ja"}
     ]
 }
 ```
@@ -51,6 +55,10 @@ And you want to add a plugin called "Foo", you would edit it to look like this:
         {"name": "twentyfourteen"},
         {"name": "twentysixteen"},
         {"name": "twentyten"}
+    ],
+    "languages": [
+        {"name": "en_GB"},
+        {"name": "ja"}
     ]
 }
 ```
@@ -59,7 +67,18 @@ Then run `whippet deps update`.
 
 Commit the updated `whippet.json`, `whippet.lock`, and `.gitignore`.
 
-### Removing a plugin 
+### Adding a language pack
+
+For language packs, note that you can add the language code for the pack (e.g. `nl_NL`) and
+Whippet will automatically install any available language packs for themes and plugins that
+are in the JSON file.
+
+To find out which languages have translation support, please see
+`https://api.wordpress.org/translations/core/1.0/?version={wp-version}` for the relevant
+version of WordPress core. Other relevant APIs can be found
+[in the codex](https://codex.wordpress.org/WordPress.org_API#Translations).
+
+### Removing a plugin
 
 Manually edit the `whippet.json` file to remove the entry for the plugin you want removed.
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,13 @@
-<phpunit bootstrap="tests/Helpers.php" backupGlobals="false" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/Helpers.php" backupGlobals="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="unit_and_integration">
       <directory suffix="_test.php">tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/spec/dependencies/dependency_types.spec.php
+++ b/spec/dependencies/dependency_types.spec.php
@@ -1,9 +1,44 @@
 <?php
 
 describe(\Dxw\Whippet\Dependencies\DependencyTypes::class, function () {
+	beforeAll(function () {
+		$this->plugins = \Dxw\Whippet\Dependencies\DependencyTypes::PLUGINS;
+		$this->themes = \Dxw\Whippet\Dependencies\DependencyTypes::THEMES;
+		$this->languages = \Dxw\Whippet\Dependencies\DependencyTypes::LANGUAGES;
+		$this->random_text = "lorem ipsum";
+	});
+
 	context("getDependencyTypes()", function () {
 		it('returns a list of dependencies as strings', function () {
-			expect(\Dxw\Whippet\Dependencies\DependencyTypes::getDependencyTypes())->toBe(['themes', 'plugins']);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::getDependencyTypes())->toBe(['themes', 'plugins', 'languages']);
+		});
+	});
+
+	context("getThemeAndPluginTypes()", function () {
+		it('returns a list of dependencies as strings without languages', function () {
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::getThemeAndPluginTypes())->toBe(['themes', 'plugins']);
+		});
+	});
+
+	context("isLanguageType()", function () {
+		it('only returns true for language types', function () {
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isLanguageType($this->plugins))->toBe(false);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isLanguageType($this->themes))->toBe(false);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isLanguageType($this->languages))->toBe(true);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isLanguageType($this->random_text))->toBe(false);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isLanguageType(""))->toBe(false);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isLanguageType(null))->toBe(false);
+		});
+	});
+
+	context("isNotLanguageType()", function () {
+		it('only returns false for language types', function () {
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isNotLanguageType($this->plugins))->toBe(true);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isNotLanguageType($this->themes))->toBe(true);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isNotLanguageType($this->languages))->toBe(false);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isNotLanguageType($this->random_text))->toBe(true);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isNotLanguageType(""))->toBe(true);
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::isNotLanguageType(null))->toBe(true);
 		});
 	});
 });

--- a/spec/dependencies/dependency_types.spec.php
+++ b/spec/dependencies/dependency_types.spec.php
@@ -1,0 +1,9 @@
+<?php
+
+describe(\Dxw\Whippet\Dependencies\DependencyTypes::class, function () {
+	context("getDependencyTypes()", function () {
+		it('returns a list of dependencies as strings', function () {
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::getDependencyTypes())->toBe(['themes', 'plugins']);
+		});
+	});
+});

--- a/spec/dependencies/describer.spec.php
+++ b/spec/dependencies/describer.spec.php
@@ -46,7 +46,7 @@ describe(Dxw\Whippet\Dependencies\Describer::class, function () {
 					'magicMethods' => true
 				]);
 				allow(\Dxw\Whippet\Git\Git::class)->toBe($git);
-				allow($git)->toReceive('::tag_for_commit')->andReturn(\Result\Result::err('Error getting tag'));
+				allow($this->factory)->toReceive('callStatic')->andReturn(\Result\Result::err('Error getting tag'));
 
 				$result = $this->describer->describe();
 
@@ -77,13 +77,11 @@ describe(Dxw\Whippet\Dependencies\Describer::class, function () {
 			],
 				[]
 			);
-			allow($this->factory)->toReceive('callStatic')->andReturn(\Result\Result::ok($whippetLock));
-			$git = Double::instance([
-				'extends' => '\Dxw\Whippet\Git\Git',
-				'magicMethods' => true
-			]);
-			allow(\Dxw\Whippet\Git\Git::class)->toBe($git);
-			allow($git)->toReceive('::tag_for_commit')->andReturn(\Result\Result::ok('v1.0.1'), \Result\Result::ok('v3.0'));
+			allow($this->factory)->toReceive('callStatic')->andReturn(
+				\Result\Result::ok($whippetLock),
+				\Result\Result::ok('v1.0.1'),
+				\Result\Result::ok('v3.0')
+			);
 
 			ob_start();
 

--- a/spec/dependencies/describer.spec.php
+++ b/spec/dependencies/describer.spec.php
@@ -75,7 +75,23 @@ describe(Dxw\Whippet\Dependencies\Describer::class, function () {
 					'revision' => 'commit-hash'
 				],
 			],
-				[]
+				[
+				[
+					'name' => 'pt_BR',
+					'src' => 'lange-one-src-for-core',
+					'revision' => '6.3.3'
+				],
+				[
+					'name' => 'pt_BR/plugins/plugin-one',
+					'src' => 'lange-one-src-for-plugin-one',
+					'revision' => '1.2.3'
+				],
+				[
+					'name' => 'pt_BR/themes/theme-one',
+					'src' => 'lange-one-src-for-theme-one',
+					'revision' => '3.2.1'
+				]
+				]
 			);
 			allow($this->factory)->toReceive('callStatic')->andReturn(
 				\Result\Result::ok($whippetLock),
@@ -95,6 +111,11 @@ describe(Dxw\Whippet\Dependencies\Describer::class, function () {
 				],
 				'plugins' => [
 					'plugin-one' => 'v3.0'
+				],
+				'languages' => [
+					"pt_BR" => "6.3.3",
+					"pt_BR/plugins/plugin-one" => "1.2.3",
+					"pt_BR/themes/theme-one" => "3.2.1"
 				]
 			]);
 			expect($result->isErr())->toBe(false);

--- a/spec/dependencies/describer.spec.php
+++ b/spec/dependencies/describer.spec.php
@@ -60,19 +60,23 @@ describe(Dxw\Whippet\Dependencies\Describer::class, function () {
 				'extends' => '\Dxw\Whippet\Files\WhippetLock',
 				'magicMethods' => true
 			]);
-			allow($whippetLock)->toReceive('getDependencies')->andReturn([
+			allow($whippetLock)->toReceive('getDependencies')->andReturn(
+				[
 				[
 					'name' => 'theme-one',
 					'src' => 'theme-one-src',
 					'revision' => 'commit-hash'
 				]
-			], [
+			],
+				[
 				[
 					'name' => 'plugin-one',
 					'src' => 'plugin-one-src',
 					'revision' => 'commit-hash'
 				],
-			]);
+			],
+				[]
+			);
 			allow($this->factory)->toReceive('callStatic')->andReturn(\Result\Result::ok($whippetLock));
 			$git = Double::instance([
 				'extends' => '\Dxw\Whippet\Git\Git',

--- a/src/Dependencies/DependencyTypes.php
+++ b/src/Dependencies/DependencyTypes.php
@@ -2,15 +2,38 @@
 
 namespace Dxw\Whippet\Dependencies;
 
+/**
+ * Encapsulate dependency types.
+ *
+ * Note that language packs are managed differently to other WordPress
+ * dependencies, and so we have some methods here that deal specifically with
+ * them. This is mainly to avoid future refactoring, for example in PHP 8
+ * this class is likely to become an enumeration.
+ */
 class DependencyTypes
 {
 	public const PLUGINS = 'plugins';
 	public const THEMES = 'themes';
+	public const LANGUAGES = 'languages';
 
 
 	public static function getDependencyTypes()
 	{
+		return [DependencyTypes::THEMES, DependencyTypes::PLUGINS, DependencyTypes::LANGUAGES];
+	}
 
+	public static function getThemeAndPluginTypes()
+	{
 		return [DependencyTypes::THEMES, DependencyTypes::PLUGINS];
+	}
+
+	public static function isLanguageType($type)
+	{
+		return $type === DependencyTypes::LANGUAGES;
+	}
+
+	public static function isNotLanguageType($type)
+	{
+		return $type !== DependencyTypes::LANGUAGES;
 	}
 }

--- a/src/Dependencies/DependencyTypes.php
+++ b/src/Dependencies/DependencyTypes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Dxw\Whippet\Dependencies;
+
+class DependencyTypes
+{
+	public const PLUGINS = 'plugins';
+	public const THEMES = 'themes';
+
+
+	public static function getDependencyTypes()
+	{
+
+		return [DependencyTypes::THEMES, DependencyTypes::PLUGINS];
+	}
+}

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -41,6 +41,9 @@ class Describer
 				$results[$type][$dep["name"]] = $result->unwrap();
 			}
 		}
+		foreach ($this->lockFile->getDependencies(DependencyTypes::LANGUAGES) as $dep) {
+			$results[DependencyTypes::LANGUAGES][$dep["name"]] = $dep['revision'];
+		}
 		return \Result\Result::ok($results);
 	}
 
@@ -51,7 +54,7 @@ class Describer
 			return $results;
 		}
 		$pretty_results = json_encode($results->unwrap(), JSON_PRETTY_PRINT);
-		printf($pretty_results);
+		printf(stripslashes($pretty_results));
 
 		return \Result\Result::ok();
 	}

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -16,7 +16,7 @@ class Describer
 		$this->dir = $dir;
 	}
 
-	public function describe()
+	public function fetchVersionInformation()
 	{
 		$resultLoad = $this->loadWhippetLock();
 		if ($resultLoad->isErr()) {
@@ -33,7 +33,16 @@ class Describer
 				$results[$type][$dep["name"]] = $result->unwrap();
 			}
 		}
-		$pretty_results = json_encode($results, JSON_PRETTY_PRINT);
+		return \Result\Result::ok($results);
+	}
+
+	public function describe()
+	{
+		$results = $this->fetchVersionInformation();
+		if ($results->isErr()) {
+			return $results;
+		}
+		$pretty_results = json_encode($results->unwrap(), JSON_PRETTY_PRINT);
 		printf($pretty_results);
 
 		return \Result\Result::ok();

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -22,10 +22,9 @@ class Describer
 		if ($resultLoad->isErr()) {
 			return $resultLoad;
 		}
-		$dependencyTypes = ['themes', 'plugins'];
 		$git = new \Dxw\Whippet\Git\Git($this->dir);
 		$results = [];
-		foreach ($dependencyTypes as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			foreach ($this->lockFile->getDependencies($type) as $dep) {
 				$result = $git::tag_for_commit($dep['src'], $dep['revision']);
 				if ($result->isErr()) {

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -24,7 +24,7 @@ class Describer
 		}
 		$git = new \Dxw\Whippet\Git\Git($this->dir);
 		$results = [];
-		foreach (DependencyTypes::getDependencyTypes() as $type) {
+		foreach (DependencyTypes::getThemeAndPluginTypes() as $type) {
 			foreach ($this->lockFile->getDependencies($type) as $dep) {
 				$result = $git::tag_for_commit($dep['src'], $dep['revision']);
 				if ($result->isErr()) {

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -16,17 +16,25 @@ class Describer
 		$this->dir = $dir;
 	}
 
-	public function fetchVersionInformation()
+	public function fetchVersionInformation($lockfileData = null)
 	{
-		$resultLoad = $this->loadWhippetLock();
-		if ($resultLoad->isErr()) {
-			return $resultLoad;
+		if (is_null($lockfileData)) {
+			$resultLoad = $this->loadWhippetLock();
+			if ($resultLoad->isErr()) {
+				return $resultLoad;
+			}
+		} else {
+			$this->lockFile = $lockfileData;
 		}
-		$git = new \Dxw\Whippet\Git\Git($this->dir);
 		$results = [];
 		foreach (DependencyTypes::getThemeAndPluginTypes() as $type) {
 			foreach ($this->lockFile->getDependencies($type) as $dep) {
-				$result = $git::tag_for_commit($dep['src'], $dep['revision']);
+				$result = $this->factory->callStatic(
+					'\\Dxw\\Whippet\\Git\\Git',
+					'tag_for_commit',
+					$dep['src'],
+					$dep['revision']
+				);
 				if ($result->isErr()) {
 					return $result;
 				}

--- a/src/Dependencies/Installer.php
+++ b/src/Dependencies/Installer.php
@@ -28,7 +28,7 @@ class Installer
 
 		$dependencies = [];
 
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$dependencies[$type] = $this->lockFile->getDependencies($type);
 		}
 

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -314,7 +314,7 @@ class Updater
 
 		foreach($this->themeAndPluginVersions as $type => $versions) {
 			foreach($versions as $name => $version) {
-				if (str_starts_with($version, 'No tags for commit')) {
+				if(substr($version, 0, 18) === 'No tags for commit') {
 					continue;
 				} else {
 					$version = $this->getCanonicalVersion($version);

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -57,7 +57,7 @@ class Updater
 
 		$allDependencies = [];
 
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$allDependencies[$type] = $this->jsonFile->getDependencies($type);
 		}
 
@@ -133,7 +133,7 @@ class Updater
 
 	private function createGitIgnore()
 	{
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			foreach ($this->jsonFile->getDependencies($type) as $dep) {
 				$this->addDependencyToIgnoresArray($type, $dep['name']);
 			}
@@ -151,7 +151,7 @@ class Updater
 		}
 
 		// Iterate through locked dependencies and remove from gitignore
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			foreach ($this->lockFile->getDependencies($type) as $dep) {
 				$line = $this->getGitignoreDependencyLine($type, $dep['name']);
 				$index = array_search($line, $this->ignores);

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -2,26 +2,34 @@
 
 namespace Dxw\Whippet\Dependencies;
 
+use Dxw\Whippet\Models\TranslationsApi;
+
 class Updater
 {
+	use \Dxw\Whippet\Modules\Helpers\WhippetHelpers;
 	private $factory;
-	private $dir;
 	private $lockFile;
 	private $jsonFile;
 	private $ignores;
 	private $gitignore;
+	private $describer;
+	// To update language packs we need version numbers for themes and plugins,
+	// hashes cannot be used with the APIs.
+	private $themeAndPluginVersions;
 
 	public function __construct(
 		\Dxw\Whippet\Factory $factory,
 		\Dxw\Whippet\ProjectDirectory $dir
 	) {
 		$this->factory = $factory;
-		$this->dir = $dir;
+		$this->project_dir = $dir;  // needed by methods from WhippetHelpers.
+		$this->describer = new Describer($factory, $dir);
+		$this->load_application_config();
 	}
 
 	public function updateSingle($dep)
 	{
-		$result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $this->dir.'/whippet.lock');
+		$result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $this->project_dir.'/whippet.lock');
 		if ($result->isErr()) {
 			echo "No whippet.lock file exists, you need to run `whippet deps update` to generate one before you can update a specific dependency. \n";
 			return \Result\Result::err(sprintf('whippet.lock: %s', $result->getErr()));
@@ -40,6 +48,15 @@ class Updater
 			return $result;
 		}
 
+		// If the single dependency is a language, we need access to version
+		// information about the existing plugins and themes in the lockfile.
+		if (DependencyTypes::isLanguageType($type)) {
+			$result = $this->getPluginAndThemeVersions(true);
+			if ($result->isErr()) {
+				return $result;
+			}
+		}
+
 		$dep = $this->jsonFile->getDependency($type, $name);
 		if ($dep === []) {
 			return \Result\Result::err('No matching dependency in whippet.json');
@@ -55,13 +72,42 @@ class Updater
 			return $result;
 		}
 
-		$allDependencies = [];
+		// Because we want to update language packs for themes and plugins,
+		// we need to update those dependencies first, so we can find version
+		// numbers for language packs associated with each theme/plugin.
+		$themeAndPluginDependencies = [];
 
-		foreach (DependencyTypes::getDependencyTypes() as $type) {
-			$allDependencies[$type] = $this->jsonFile->getDependencies($type);
+		foreach (DependencyTypes::getThemeAndPluginTypes() as $type) {
+			$themeAndPluginDependencies[$type] = $this->jsonFile->getDependencies($type);
 		}
 
-		return $this->update($allDependencies);
+		$result = $this->getPluginAndThemeVersions(false);
+		if ($result->isErr()) {
+			return $result;
+		}
+
+		$allDependencies = $themeAndPluginDependencies;
+		$allDependencies[DependencyTypes::LANGUAGES] = $this->jsonFile->getDependencies(DependencyTypes::LANGUAGES);
+
+		$result = $this->update($allDependencies);
+		if ($result->isErr()) {
+			return $result;
+		}
+		return \Result\Result::ok();
+	}
+
+	private function getPluginAndThemeVersions($fromLockfile = false)
+	{
+		$result = $fromLockfile ? $this->describer->fetchVersionInformation() : $this->describer->fetchVersionInformation($this->lockFile);
+		if ($result->isErr()) {
+			return $result;
+		}
+		$versions = $result->unwrap();
+		if (array_key_exists(DependencyTypes::LANGUAGES, $versions)) {
+			unset($versions[DependencyTypes::LANGUAGES]);
+		}
+		$this->themeAndPluginVersions = $versions;
+		return \Result\Result::ok();
 	}
 
 	private function update(array $dependencies)
@@ -98,19 +144,19 @@ class Updater
 
 	private function saveChanges()
 	{
-		$this->lockFile->saveToPath($this->dir.'/whippet.lock');
+		$this->lockFile->saveToPath($this->project_dir.'/whippet.lock');
 		$this->createGitIgnore();
 	}
 
 	private function loadWhippetFiles()
 	{
-		$result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $this->dir.'/whippet.json');
+		$result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $this->project_dir.'/whippet.json');
 		if ($result->isErr()) {
 			return \Result\Result::err(sprintf('whippet.json: %s', $result->getErr()));
 		}
 		$this->jsonFile = $result->unwrap();
 
-		$result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $this->dir.'/whippet.lock');
+		$result = $this->factory->callStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $this->project_dir.'/whippet.lock');
 		if ($result->isErr()) {
 			$this->lockFile = $this->factory->newInstance('\\Dxw\\Whippet\\Files\\WhippetLock', []);
 		} else {
@@ -122,7 +168,7 @@ class Updater
 
 	private function updateHash()
 	{
-		$contents = file_get_contents($this->dir.'/whippet.json');
+		$contents = file_get_contents($this->project_dir.'/whippet.json');
 
 		// Strip CR for git/Windows compatibility
 		$contents = strtr($contents, ["\r" => '']);
@@ -143,10 +189,10 @@ class Updater
 
 	private function loadGitignore()
 	{
-		$this->gitignore = $this->factory->newInstance('\\Dxw\\Whippet\\Git\\Gitignore', (string) $this->dir);
+		$this->gitignore = $this->factory->newInstance('\\Dxw\\Whippet\\Git\\Gitignore', (string) $this->project_dir);
 
 		$this->ignores = [];
-		if (is_file($this->dir.'/.gitignore')) {
+		if (is_file($this->project_dir.'/.gitignore')) {
 			$this->ignores = $this->gitignore->get_ignores();
 		}
 
@@ -160,6 +206,7 @@ class Updater
 				}
 			}
 		}
+		$this->ignores = array_values($this->ignores);
 	}
 
 	private function addDependencyToIgnoresArray($type, $name)
@@ -169,10 +216,22 @@ class Updater
 
 	private function getGitignoreDependencyLine($type, $name)
 	{
+		if (DependencyTypes::isLanguageType($type)) {
+			// Plugin language packs go in /wp-content/languages/plugins/
+			return '/wp-content/'.$type."\n";
+		}
 		return '/wp-content/'.$type.'/'.$name."\n";
 	}
 
 	private function addDependencyToLockfile($type, array $dep)
+	{
+		if (DependencyTypes::isLanguageType($type)) {
+			return $this->addLanguageToLockfile($dep);
+		}
+		return $this->addThemeOrPluginToLockfile($type, $dep);
+	}
+
+	private function addThemeOrPluginToLockfile($type, array $dep)
 	{
 		if (isset($dep['src'])) {
 			$src = $dep['src'];
@@ -216,5 +275,66 @@ class Updater
 		}
 
 		return $this->fetchRef($src, 'master');
+	}
+
+	/**
+	 * Version strings passed to WordPress APIs must not start with a v.
+	 *
+	 * So, v6.3.1 becomes 6.3.1.
+	 */
+	private function getCanonicalVersion($version)
+	{
+		if(str_starts_with($version, 'v')) {
+			return substr($version, 1);
+		}
+		return $version;
+	}
+
+	/**
+	 * Add a language pack to a lockfile, including translations for themes and plugins.
+	 *
+	 * Note that a missing language pack for WordPress Core is considered an
+	 * error here, but a missing translation for a plugin or theme is not.
+	 *
+	 * The WordPress APIs do not expect versions to start with a v, i.e. if a
+	 * revision number is 'v1.2.3' we pass in '1.2.3'.
+	 */
+	private function addLanguageToLockfile(array $dep)
+	{
+		$wpCoreVersion = $this->getCanonicalVersion($this->get_wordpress_core_version());
+		$result = TranslationsApi::fetchLanguageSrcAndRevision(DependencyTypes::LANGUAGES, $dep['name'], $wpCoreVersion, null);
+		if ($result->isErr()) {
+			return $result;
+		}
+		list($src, $revision) = $result->unwrap();
+		if (is_null($src)) {
+			return \Result\Result::err("{$dep['name']} is not available for WordPress Core.");
+		}
+		$this->lockFile->addDependency(DependencyTypes::LANGUAGES, $dep['name'], $src, $revision);
+
+		foreach($this->themeAndPluginVersions as $type => $versions) {
+			foreach($versions as $name => $version) {
+				if (str_starts_with($version, 'No tags for commit')) {
+					continue;
+				} else {
+					$version = $this->getCanonicalVersion($version);
+				}
+				$result = TranslationsApi::fetchLanguageSrcAndRevision($type, $dep['name'], $version, $name);
+				if ($result->isErr()) {
+					echo sprintf("* Error encountered in updating {$dep['name']} translations for {$name} {$version}.\n");
+					echo sprintf("    {$result->getErr()}\n");
+					continue;
+				}
+				list($src, $revision) = $result->unwrap();
+				if (is_null($src)) {
+					echo sprintf("* No {$dep['name']} language pack available for {$name} {$version}.\n");
+				} else {
+					$translation = $dep['name'].'/'.$type.'/'.$name;
+					$this->lockFile->addDependency(DependencyTypes::LANGUAGES, $translation, $src, $revision);
+				}
+			}
+		}
+
+		return \Result\Result::ok();
 	}
 }

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -278,19 +278,6 @@ class Updater
 	}
 
 	/**
-	 * Version strings passed to WordPress APIs must not start with a v.
-	 *
-	 * So, v6.3.1 becomes 6.3.1.
-	 */
-	private function getCanonicalVersion($version)
-	{
-		if(str_starts_with($version, 'v')) {
-			return substr($version, 1);
-		}
-		return $version;
-	}
-
-	/**
 	 * Add a language pack to a lockfile, including translations for themes and plugins.
 	 *
 	 * Note that a missing language pack for WordPress Core is considered an
@@ -301,7 +288,7 @@ class Updater
 	 */
 	private function addLanguageToLockfile(array $dep)
 	{
-		$wpCoreVersion = $this->getCanonicalVersion($this->get_wordpress_core_version());
+		$wpCoreVersion = $this->get_bare_version_number($this->get_wordpress_core_version());
 		$result = TranslationsApi::fetchLanguageSrcAndRevision(DependencyTypes::LANGUAGES, $dep['name'], $wpCoreVersion, null);
 		if ($result->isErr()) {
 			return $result;
@@ -317,7 +304,7 @@ class Updater
 				if(substr($version, 0, 18) === 'No tags for commit') {
 					continue;
 				} else {
-					$version = $this->getCanonicalVersion($version);
+					$version = $this->get_bare_version_number($version);
 				}
 				$result = TranslationsApi::fetchLanguageSrcAndRevision($type, $dep['name'], $version, $name);
 				if ($result->isErr()) {

--- a/src/Dependencies/Validator.php
+++ b/src/Dependencies/Validator.php
@@ -49,7 +49,9 @@ class Validator
 		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$whippetJsonDependencies = $whippetJson->getDependencies($type);
 			$whippetLockDependencies = $whippetLock->getDependencies($type);
-			if (count($whippetJsonDependencies) !== count($whippetLockDependencies)) {
+			if (DependencyTypes::isLanguageType($type) && count($whippetJsonDependencies) > count($whippetLockDependencies)) {
+				return \Result\Result::err(sprintf('Mismatched dependencies count for type %s', $type));
+			} elseif (DependencyTypes::isNotLanguageType($type) && count($whippetJsonDependencies) !== count($whippetLockDependencies)) {
 				return \Result\Result::err(sprintf('Mismatched dependencies count for type %s', $type));
 			}
 

--- a/src/Dependencies/Validator.php
+++ b/src/Dependencies/Validator.php
@@ -46,7 +46,7 @@ class Validator
 
 		// Check that entries in whippet.json
 		// match entries in whippet.lock
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$whippetJsonDependencies = $whippetJson->getDependencies($type);
 			$whippetLockDependencies = $whippetLock->getDependencies($type);
 			if (count($whippetJsonDependencies) !== count($whippetLockDependencies)) {

--- a/src/Git/Gitignore.php
+++ b/src/Git/Gitignore.php
@@ -45,7 +45,7 @@ class Gitignore
 	private function ensure_closing_newline($ignores)
 	{
 		$index_of_last_line = count($ignores) - 1;
-		$last_line = $ignores[$index_of_last_line];
+		$last_line = $index_of_last_line >= 0 ? $ignores[$index_of_last_line] : 0;
 		$last_character = substr($last_line, -1);
 
 		if ($last_character != "\n") {

--- a/src/Models/TranslationsApi.php
+++ b/src/Models/TranslationsApi.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Dxw\Whippet\Models;
+
+use Dxw\Whippet\Dependencies\DependencyTypes;
+
+class TranslationsApi
+{
+	/**
+	 * Fetch language packs for a given language, and type.
+	 *
+	 * WordPress provides language packs for core, themes and plugins, so we
+	 * fetch any that are available for the given type. Core language packs
+	 * do not require a slug to be passed in, but all require a version, which
+	 * should not start with 'v'.
+	 */
+	public static function fetchLanguageSrcAndRevision($type, $language, $version, $slug)
+	{
+		if ($type == DependencyTypes::LANGUAGES) {
+			$url = "https://api.wordpress.org/translations/core/1.0/?version={$version}";
+		} elseif ($type == DependencyTypes::PLUGINS) {
+			$url = "https://api.wordpress.org/translations/plugins/1.0/?slug={$slug}&version={$version}";
+		} elseif ($type == DependencyTypes::THEMES) {
+			$url = "https://api.wordpress.org/translations/themes/1.0/?slug={$slug}&version={$version}";
+		} else {
+			return [null, null];
+		}
+
+		try {
+			$data = file_get_contents($url);
+		} catch (\Exception $exn) {
+			return \Result\Result::err("got error: {$exn->getMessage()} on downloading: {$url}");
+		}
+		try {
+			$allTranslations = json_decode($data, JSON_OBJECT_AS_ARRAY);
+		} catch (\Exception $exn) {
+			return \Result\Result::err("got error: {$exn->getMessage()} on decoding JSON from {$url}");
+		}
+		foreach($allTranslations['translations'] as $translation) {
+			if ($translation['language'] == $language) {
+				$src = stripslashes($translation['package']);
+				$revision = $translation['version'];
+				return \Result\Result::ok([$src, $revision]);
+			}
+		}
+		return \Result\Result::ok([null, null]);
+	}
+}

--- a/src/Modules/Helpers/WhippetHelpers.php
+++ b/src/Modules/Helpers/WhippetHelpers.php
@@ -114,9 +114,7 @@ trait WhippetHelpers
 		$canonical_version = $this->get_bare_version_number($config_version);
 		$ver_len = strlen($canonical_version);
 		while ($i < count($latest_core_version['offers'])) {
-			print_r("counter: {$i} canonical version: {$canonical_version}\n");
 			if (substr($latest_core_version['offers'][$i]['version'], 0, $ver_len) === $canonical_version) {
-				print_r("VERSION: {$latest_core_version['offers'][$i]['version']}\n");
 				return $latest_core_version['offers'][$i]['version'];
 			}
 			$i++;

--- a/src/Modules/Helpers/WhippetHelpers.php
+++ b/src/Modules/Helpers/WhippetHelpers.php
@@ -72,14 +72,56 @@ trait WhippetHelpers
 		}
 	}
 
+	/**
+	 * Version strings passed to WordPress APIs must not start with a v.
+	 *
+	 * So, v6.3.1 becomes 6.3.1.
+	 */
+	public function get_bare_version_number($version)
+	{
+		if(substr($version, 0, 1) === 'v') {
+			return substr($version, 1);
+		}
+		return $version;
+	}
+
+	/** Given a version in config/application.json, return a valid WP Core version.
+	 *
+	 * Note that version numbers in repos can be of the following forms:
+	 *
+	 * v6
+	 * 6.3.2
+	 * 6.3
+	 * 6
+	 *
+	 * and should be translated into a full semver version, e.g. 6.3.2.
+	 */
 	public function get_wordpress_core_version()
 	{
 		$config_version = $this->application_config->wordpress->revision;
+		if (substr_count($config_version, '.') === 2) {
+			return $config_version;
+		}
 		if ($config_version == 'master') {
 			$latest_core_version = json_decode(file_get_contents('https://api.wordpress.org/core/version-check/1.7/'), JSON_OBJECT_AS_ARRAY);
 			return $latest_core_version['offers'][0]['version'];
 		}
-		return $config_version;
+		// Version does not include a patch version, so we need to find the
+		// fully qualified version humber from the JSON. We assume that the
+		// JSON data is ordered by most recent release first.
+		$latest_core_version = json_decode(file_get_contents('https://api.wordpress.org/core/version-check/1.7/'), JSON_OBJECT_AS_ARRAY);
+		$i = 0;
+		$canonical_version = $this->get_bare_version_number($config_version);
+		$ver_len = strlen($canonical_version);
+		while ($i < count($latest_core_version['offers'])) {
+			print_r("counter: {$i} canonical version: {$canonical_version}\n");
+			if (substr($latest_core_version['offers'][$i]['version'], 0, $ver_len) === $canonical_version) {
+				print_r("VERSION: {$latest_core_version['offers'][$i]['version']}\n");
+				return $latest_core_version['offers'][$i]['version'];
+			}
+			$i++;
+		}
+		throw new \Exception("WordPress core version not valid or no longer available: {$config_version}");
 	}
 
 	public function find_file($file, $include_dir = false)

--- a/src/Modules/Helpers/WhippetHelpers.php
+++ b/src/Modules/Helpers/WhippetHelpers.php
@@ -72,6 +72,16 @@ trait WhippetHelpers
 		}
 	}
 
+	public function get_wordpress_core_version()
+	{
+		$config_version = $this->application_config->wordpress->revision;
+		if ($config_version == 'master') {
+			$latest_core_version = json_decode(file_get_contents('https://api.wordpress.org/core/version-check/1.7/'), JSON_OBJECT_AS_ARRAY);
+			return $latest_core_version['offers'][0]['version'];
+		}
+		return $config_version;
+	}
+
 	public function find_file($file, $include_dir = false)
 	{
 		// Starting in the current dir, walk up until we find the file

--- a/src/Services/InspectionChecker.php
+++ b/src/Services/InspectionChecker.php
@@ -21,6 +21,8 @@ class InspectionChecker
 				return \Result\Result::ok('');
 			case 'plugins':
 				return $this->checkPlugin($dependency);
+			case 'languages':
+				return \Result\Result::ok('');
 			default:
 				return \Result\Result::err("Unknown type '".$type."'");
 		}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -114,10 +114,27 @@ trait Helpers
 		return new \Dxw\Whippet\ProjectDirectory($dir);
 	}
 
+	private function createDefaultApplicationJson($path)
+	{
+		$data = ["wordpress" => ["repository" => "git@git.example.com:wordpress/snapshot", "revision" => "6.3.1"]];
+		$json = json_encode($data);
+		$bytes = file_put_contents($path, $json);
+	}
+
+	private function getDirWithDefaults()
+	{
+		$dir = $this->getDir();
+		mkdir($dir.'/config');
+		touch($dir.'/config/application.json');
+		$this->createDefaultApplicationJson($dir."/config/application.json");
+		mkdir($dir.'/wp-content');
+		mkdir($dir.'/wp-content/plugins');
+		return $dir;
+	}
+
 	private function getDir()
 	{
 		$root = \org\bovigo\vfs\vfsStream::setup();
-
 		return $root->url();
 	}
 }

--- a/tests/dependencies/installer_test.php
+++ b/tests/dependencies/installer_test.php
@@ -41,6 +41,7 @@ class DependenciesInstallerTest extends \PHPUnit\Framework\TestCase
 				$my_plugin,
 				$another_plugin,
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -67,7 +68,8 @@ EOT;
 				'plugins' => [
 					'my-plugin' =>  \Result\Result::ok($warning_msg),
 					'another-plugin' => \Result\Result::ok("Inspections for this plugin:\n* 01/05/2015 - 0.1.3 - No issues found - https://advisories.dxw.com/plugins/another_plugin/")
-				]
+					],
+					[],
 			][$type][$dep['name']];
 		};
 
@@ -124,6 +126,7 @@ EOT;
 			'plugins' => [
 				$my_plugin,
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -179,6 +182,7 @@ EOT;
 				],
 			],
 			'plugins' => [],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -279,6 +283,7 @@ EOT;
 				],
 			],
 			'plugins' => [],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -315,6 +320,7 @@ EOT;
 				],
 			],
 			'plugins' => [],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -345,6 +351,7 @@ EOT;
 		$whippetLock = $this->getWhippetLock(sha1('foobar'), [
 			'themes' => [],
 			'plugins' => [],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -388,6 +395,7 @@ EOT;
 					'revision' => '789abc',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -449,6 +457,7 @@ EOT;
 					'revision' => '789abc',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -483,6 +492,7 @@ EOT;
 				],
 			],
 			'plugins' => [],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -519,6 +529,7 @@ EOT;
 				],
 			],
 			'plugins' => [],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 

--- a/tests/dependencies/updater_test.php
+++ b/tests/dependencies/updater_test.php
@@ -53,6 +53,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 			$getDependencies = [
 				['themes', []],
 				['plugins', []],
+				['languages', []],
 			];
 		}
 
@@ -83,6 +84,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -131,6 +133,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.4',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -183,6 +186,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.4',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -235,6 +239,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.4',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -279,6 +284,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'src' => 'foobar',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -322,6 +328,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'name' => 'my-theme',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -365,6 +372,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'name' => 'my-theme',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -445,6 +453,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -493,6 +502,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.4',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -515,6 +525,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 			['plugins', [
 				['name' => 'removed-plugin'],
 			]],
+			['languages', []],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
@@ -575,6 +586,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -629,6 +641,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -723,6 +736,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -763,6 +777,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -809,6 +824,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.4',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -861,6 +877,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.4',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -918,6 +935,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'name' => 'twitget',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -970,6 +988,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'src' => 'foobar',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -1019,6 +1038,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'name' => 'my-plugin',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -1071,6 +1091,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
@@ -1125,6 +1146,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 					'ref' => 'v1.6',
 				],
 			],
+			'languages' => [],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 

--- a/tests/services/inspection_checker_test.php
+++ b/tests/services/inspection_checker_test.php
@@ -35,7 +35,8 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
 			'revision' => '123456',
 		];
 		$checker = new \Dxw\Whippet\Services\InspectionChecker($api);
-		$checker->check('plugins', $my_plugin);
+		$result = $checker->check('plugins', $my_plugin);
+		$this->assertFalse($result->isErr());
 	}
 
 	public function testPluginWithNoInspectionsGeneratesMessage()

--- a/tests/services/inspections_api_test.php
+++ b/tests/services/inspections_api_test.php
@@ -16,7 +16,9 @@ class Inspections_Api_Test extends \PHPUnit\Framework\TestCase
 			->andReturn(\Result\Result::ok([]));
 
 		$api = new \Dxw\Whippet\Services\InspectionsApi('https://advisories.dxw.com', '/wp-json/v1/inspections/', $json_api);
-		$api->getInspections('my-plugin');
+		$result = $api->getInspections('my-plugin');
+		$this->assertFalse($result->isErr());
+		$this->assertEquals([], $result->unwrap());
 	}
 
 	public function testNoInspections()

--- a/tests/services/json_api_test.php
+++ b/tests/services/json_api_test.php
@@ -16,7 +16,9 @@ class Json_Api_Test extends \PHPUnit\Framework\TestCase
 			->andReturn(\Result\Result::ok('[]'));
 
 		$api = new \Dxw\Whippet\Services\JsonApi($base_api);
-		$api->get('http://apisite.com/api/endpoint');
+		$result = $api->get('http://apisite.com/api/endpoint');
+		$this->assertFalse($result->isErr());
+		$this->assertEquals([], $result->unwrap());
 	}
 
 	public function testEmptyResponse()


### PR DESCRIPTION
* Resolves #4 
* Resolves #70
* Related to #226
* Related to #227

## Summary

This PR adds the ability to manage WordPress language packs with Whippet. Once this PR is merged, it should be possible to run any `whippet deps ...` command with `languages` as a dependency (rather than `plugins` or `themes`). Commands that do not specify a dependency type (e.g. `whippet deps validate`) should now take language packs into account.

## About WordPress language packs

WordPress language packs are slightly different to other dependency types (core, plugins, themes) and those differences complicate this PR.

Language packs are versioned separately, but they are _available_ for all other dependency types. So, installing the `pt_BR` language pack might install translations for WordPress Core, and for a number of plugins and themes that are also managed by Whippet.

Whereas with other dependencies we mirror the repositories for each dependency, in this PR we have opted not to do that, due to the complexity of retrieving the "correct" translation packs for each dependency. Instead, we rely on the `wordpress.org` APIs to describe the location of each translation. 

For example, if we have a repo pinned to version 6.3.3 of WordPress Core, which  uses the `classic-editor` plugin and the `twentytwenty` theme, and we want to install `pt_BR` translations, we would query the following JSON APIs to find the URI for each language pack:

* WordPress Core 6.3.1: [`https://api.wordpress.org/translations/core/1.0/?version=6.3.3`](https://api.wordpress.org/translations/core/1.0/?version=6.3.3)
* `classic-editor` v1.6.3: [`https://api.wordpress.org/translations/plugins/1.0/?slug=classic-editor&version=1.6.3`](https://api.wordpress.org/translations/plugins/1.0/?slug=classic-editor&version=1.6.3)
* `twentytwenty` v1.0.0: [`https://api.wordpress.org/translations/themes/1.0/?slug=twentytwenty&version=1.0.0`](https://api.wordpress.org/translations/themes/1.0/?slug=twentytwenty&version=1.0.0)

This is equivalent to the behaviour of wp-cli which provides commands for manually installing and removing translations, e.g.

```shell
wp language core install
wp language plugin classic-editor ja
wp language theme install twentytwenty ja
```

## The `whippet.json` and `whippet.lock` files

To add language packs to the Whippet dependencies of a repository, the country codes for the languages should be added to the JSON file, e.g.:

```json
     "languages": [
        {"name": "en_GB"},
        {"name": "pt_BR"},
        {"name": "ja"}
    ]
```

On running `whippet deps update` the lockfile will be populated with information from the `wordpress.org` APIs. Language codes are considered valid if and only if a translation is available for the current pinned version of WordPress Core.

Note that here, the `revision` for each entry is the revision of the relevant dependency. So, `6.3.1` in the example below refers to the version of WordPress Core, _not_ the version of the translation files, which are versioned separately.

The code in Whippet expects that each lockfile object will contain a `name`, a `src` and a `revision`. For language packs, we may want to install a number of different translation packs for each country code. Rather than complicate the code that manages lockfiles by adding more attributes to the lockfile objects, I have opted to encode dependency types in the names of each translation. So, the `pt_BR` translations for the `twentytwenty` theme would be encoded as `pt_BR/themes/twentytwenty`.

For example:

```json
    "languages": [
        {
            "name": "ja",
            "src": "https://downloads.wordpress.org/translation/core/6.3.1/ja.zip",
            "revision": "6.3.1"
        },
        {
            "name": "ja/plugins/classic-editor",
            "src": "https://downloads.wordpress.org/translation/plugin/classic-editor/1.6.3/ja.zip",
            "revision": "1.6.3"
        },
        {
            "name": "ja/plugins/pdf-image-generator",
            "src": "https://downloads.wordpress.org/translation/plugin/pdf-image-generator/1.5.6/ja.zip",
            "revision": "1.5.6"
        }
    ]
```

## About this PR

Whippet is not as compliant with the SOLID principles as it might be, which means that some parts of the code are not well encapsulated and there are several hidden dependencies.

Because of this, I have made some compromises to ship this code in a reasonable timeframe, without completely refactoring the codebase.

In particular:

* As described above, the lockfile uses dependency names to encode more information than just the language code for a translation pack.
* There are several places in this PR where we switch on dependency type, e.g.:
```php
foreach (DependencyTypes::getThemeAndPluginTypes() as $type) {
    ...
}
foreach (DependencyTypes::LANGUAGES) as $dep) {
    ...
}
```
Switching on type is a code smell, and ideally dependency types would be able to update and install "themselves". However, the current code structure in Whippet is that we have classes for commands, not classes for dependencies, and so this would require a large refactoring of code that does no have good test coverage.
* There is a dependency between language packs and other dependency types. We need to fetch version information for all other dependencies before we fetch information about language packs, so that we can query the `wordpress.org` APIs with version information about plugins and themes. This dependency would exist whether we refactor the code or not, and is another reason for switching on dependency type in this branch.
* We are not yet using PHP 8.x everywhere, and so support for PHP 7.4 needs to persist. Because of this `DependencyTypes` is a class with constants, and not an enumeration.

## Preparing for manual testing

If you have `whippet` installed system-wide, you might want to create an alias for testing this branch, i.e.:

```shell
alias whippet-test='<path-to-whippet-clone>/whippet/bin/whippet'
```

Most Whippet commands require a Whippetised repository with some default files and directories. You might want to create some structures in `/tmp` for testing.

To run `whippet deps update` you need a minimum set of files and directories:

* A valid `whippet.json` file
* `.gitignore`
* `config/`
* `wp-content/`
* `wp-content/plugins/`

It's a good idea to have at least one plugin with language packs, maybe `classic-editor` or `akismet`. 

To run `whippet deploy` you need a slightly different directory structure:

```shell
<path>/shared/uploads
<path>/shared/wp-config.php
```

The `wp-config.php` file should look like this:

```php
<?php
define('DB_NAME', 'placeholder');
define('DB_PASSWORD', 'placeholder');
define('DB_HOST', 'placeholder');
```

Then you can create a new whippet app with `whippet generate app`, move to the `whippet-app` directory and run `whippet deps update` to install the dependencies. `whippet deploy ../` can be run from within `whippet-app`. 

More information can be found in [the documentation](https://github.com/dxw/whippet/tree/main/docs).

## Testing

* Run `./script/test`
* Test that this branch works as expected without any language packs. Dependency commands are: `describe`, `validate`, `install`, `update`. You might also want to check `deploy` and `release` with and without language packs.
* Add some languages to the JSON, for example:

```json
    "languages": [
        {"name": "en_GB"},
        {"name": "ja"}
    ]
```

* Run `whippet deps update` to populate the lockfile and install all dependencies
* Run `whippet deps validate` to check that the new lockfile is valid
* Run `whippet deps install` (should be idempotent to `update`)
* Check the Git ignore file, the Whippet lockfile and `wp-content/languages`. There may also be a `wp-content/languages/plugins` directory.
* You may want to remove the `wp-content/languages` directory, and install the same things via wp-cli to check the install, e.g.:

```shell
wp language core install
wp language plugin classic-editor ja
wp language theme install twentytwenty ja
```
* Remove the `wp-content/languages` directory and run `whippet deps update languages/ja` or similar to check that a single language pack can be manually updated. Expected behaviour is that the language pack will be installed for core _and_ relevant themes and plugins.
* Check that adding an invalid language code to `whippet.json` returns an error message on `whippet deps update`.


----

- [x] Includes tests (if new features are introduced)
- [x] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
