### PR TITLE
whippet deps describe shows the most detailed semver version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `whippet generate app` generates an app which can be deployed by Whippet.
+- `whippet deps describe` always prints the most detailed semver version available.
 
 ### Added
 - Support for PHP 8

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -374,6 +374,10 @@ class Git
 			return \Result\Result::ok('No tags for commit ' . $commit_hash);
 		}
 
+		usort($tags_array, function ($a, $b) {
+			return strlen($b) <=> strlen($a);
+		});
+
 		$resultArray = explode('/', $tags_array[0]);
 		$result = str_replace("^{}", "", end($resultArray));
 


### PR DESCRIPTION
In our plugin repositories, we now tag commits with major version tags, e.g. 'v1' and more detailed tags, e.g. 'v1.2.3'.

When we run 'whippet deps describe' we always want the version number with the most fidelity.

Resolves: https://...

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 

### Testing

In a project repo, run `whippet deps update` both on this branch and from `main`. You should see differences like this:

```shell
❯ whippet-test deps describe
{
    "plugins": {
        ...
        "advanced-custom-fields-pro": "v6",
    }
}%
```

vs

```shell
❯ whippet-test deps describe
{
    "plugins": {
        ...
        "advanced-custom-fields-pro": "v6.2.5",
    }
}%
```