### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.0] - 2024-01-29
 
 ### Changed
 - `whippet generate app` generates an app which can be deployed by Whippet.


### PR DESCRIPTION
This will fix the issue we're seeing in GovPress Tools vulnerability alerts, and GovPress Tools-generated comments on PRs updating `whippet.lock` files, where the major version tag, rather than the full version tag, is used, resulting in incorrect output.

- [x] Changelog updated
- [x] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number: draft PR [here](https://github.com/dxw/homebrew-tap/pull/33). Can only be fully updated once the sha for the zip of the latest release is known
