### PR TITLE
Run 'git fetch' with '--force' if no revision given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2024-03-11
+
+### Changed
+- Fixed 'would clobber existing tag' error when running 'git fetch'
+
 ## [2.4.0] - 2024-01-29
 
 ### Changed

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -41,7 +41,7 @@ class Git
 
 	public function checkout($revision)
 	{
-		list($output, $return) = $this->run_command(['git', 'fetch', '-a', '&&', 'git', 'checkout', $revision]);
+		list($output, $return) = $this->run_command(['git', 'fetch', '-a', '--force', '&&', 'git', 'checkout', $revision]);
 
 		return $this->check_git_return('Checkout failed', $return, $output);
 	}
@@ -213,7 +213,7 @@ class Git
 
 	public function fetch()
 	{
-		list($output, $return) = $this->run_command(['git', 'fetch', '-a']);
+		list($output, $return) = $this->run_command(['git', 'fetch', '-a', '--force']);
 
 		return $this->check_git_return('Checkout failed', $return, $output);
 	}


### PR DESCRIPTION
When we run `git fetch` without a specific revision we usually run it with `--all` which fetches tags (among other things).

We now have movable tags in our plugin repositories and when a tag is moved a `git fetch` or `checkout` will produce a 'would clobber existing tag' error on the command line, which warns the user that the tag that has already been checked into the local clone will be overwritten.

This commit fixes that error by running `fetch` with `--force` if we do not specify a revision.

## Testing 

This can only be tested if you have a repo checked out with a major revision tag of a plugin which has been moved, in which case you will see `would clobber existing tag` when you run `whippet deps update`. At this point, you can try the same thing with this branch and see if that fixes the issue.

## Merge checklist

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [x] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
