### PR TITLE
Feature/warn user on archived GitHub repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2024-05-28
+
+### Changed
+- Users are now warned if they pull from an archived GitHub repository
+
 ## [2.4.1] - 2024-03-11
 
 ### Changed

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -31,8 +31,22 @@ trait Helpers
 		return $whippetLock;
 	}
 
-	private function getGit($isRepo, $cloneRepo, $checkout)
+	private function getArchivedWarning()
 	{
+		$warning = <<<'EOT'
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! WARNING: GitHub repo is archived. This dependency !!
+!! should be replaced before the repo is removed.    !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+EOT;
+		return $warning;
+	}
+
+	private function getGit($isRepo, $cloneRepo, $checkout, $isArchived = false)
+	{
+		$archived_warning = $this->getArchivedWarning();
+
 		$git = $this->getMockBuilder('\\Dxw\\Whippet\\Git\\Git')
 		->disableOriginalConstructor()
 		->getMock();
@@ -42,6 +56,11 @@ trait Helpers
 
 		if ($cloneRepo !== null) {
 			$return = true;
+			$output = "git clone output\n";
+
+			if ($isArchived) {
+				$output = $archived_warning . $output;
+			}
 
 			if (is_array($cloneRepo)) {
 				$return = $cloneRepo['return'];
@@ -51,8 +70,8 @@ trait Helpers
 			$git->expects($this->exactly(1))
 			->method('clone_repo')
 			->with($cloneRepo)
-			->will($this->returnCallback(function () use ($return) {
-				echo "git clone output\n";
+			->will($this->returnCallback(function () use ($output, $return) {
+				echo $output;
 
 				return $return;
 			}));
@@ -60,6 +79,11 @@ trait Helpers
 
 		if ($checkout !== null) {
 			$return = true;
+			$output = "git checkout output\n";
+
+			if ($isArchived) {
+				$output = $archived_warning . $output;
+			}
 
 			if (is_array($checkout)) {
 				$return = $checkout['return'];
@@ -69,8 +93,8 @@ trait Helpers
 			$git->expects($this->exactly(1))
 			->method('checkout')
 			->with($checkout)
-			->will($this->returnCallback(function () use ($return) {
-				echo "git checkout output\n";
+			->will($this->returnCallback(function () use ($output, $return) {
+				echo $output;
 
 				return $return;
 			}));


### PR DESCRIPTION
Warn user if they pull from an archived GitHub repo

This commit issues a warning to the user if they clone or checkout from an
archived GitHub repository. In dxw, archiving a GitHub repository containing
a dependency is likely to mean that the repository will soon be removed, and
so we need to make users aware of this. However, we do not want to cause
an error here, because we do not know whether Whippet is being run in the
context of a local development environment or as part of a deploy process.

Note that because we are only enabling this feature for a specific dxw use case,
this commit does not make the effort to abstract out GitHub-specific code in
a way that would make it easy to generalise the feature for GitLab, BitBucket,
etc. This can be done in a future PR, if anyone needs it, but ideally we would
want to improve the unit tests before hand.

## Testing

Create a `whippet.json` file with an archived repository, for example:

```json
{
  "plugins": [
     {"name": "ht-body-exporter", "src": "https://github.com/dxw/ht-body-exporter"}
  ]
}
```

and run `whippet deps update`. Check that a warning is printed.

Remove the lockfile and create a new `whippet.json` with a non-archived reposistory, e.g.:

```json
{
  "plugins": [
     {"name": "dxw-members-only", "src": "https://github.com/dxw/dxw-members-only"}
  ]
}
```

and run `whippet deps update`. Check that a warning is _not_ printed.

----

- [x] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
