### PR TITLE
Add option to enforce refs on `whippet deps validate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Option to enforce refs when running `whippet deps validate`
+
 ## [2.4.2] - 2024-05-28
 
 ### Changed

--- a/src/Dependencies/Validator.php
+++ b/src/Dependencies/Validator.php
@@ -15,7 +15,7 @@ class Validator
 		$this->dir = $dir;
 	}
 
-	public function validate()
+	public function validate(bool $enforceRefs = false)
 	{
 		$whippetLock = $this->loadWhippetLock();
 		if ($whippetLock->isErr()) {
@@ -56,6 +56,11 @@ class Validator
 			foreach ($whippetJsonDependencies as $whippetJsonDependency) {
 				if (!$this->lockMatchFoundForDependency($whippetJsonDependency, $whippetLockDependencies)) {
 					return \Result\Result::err(sprintf('No entry found in whippet.lock for %s: %s', $type, $whippetJsonDependency["name"]));
+				}
+				if ($enforceRefs) {
+					if (!array_key_exists('ref', $whippetJsonDependency)) {
+						return \Result\Result::err(sprintf("Missing reference in whippet.json for %s: %s", $type, $whippetJsonDependency["name"]));
+					}
 				}
 			}
 

--- a/src/Modules/Dependencies.php
+++ b/src/Modules/Dependencies.php
@@ -32,7 +32,9 @@ class Dependencies extends \RubbishThorClone
 		};
 		$this->command('install', 'Installs dependencies', $inspections_host_option);
 		$this->command('update', 'Updates dependencies to their latest versions. Use deps update [type]/[name] to update a specific dependency', $inspections_host_option);
-		$this->command('validate', 'Validate whippet.json and whippet.lock files');
+		$this->command('validate', 'Validate whippet.json and whippet.lock files', function ($option_parser) {
+			$option_parser->addRule('r|enforce-refs', "Enforce refs for all whippet dependencies");
+		});
 		$this->command('describe', 'List dependencies and their versions');
 	}
 
@@ -78,7 +80,8 @@ class Dependencies extends \RubbishThorClone
 	{
 		$dir = $this->getDirectory();
 		$validator = new \Dxw\Whippet\Dependencies\Validator($this->factory, $dir);
-		$this->exitIfError(($validator->validate()));
+		$enforceRefs = isset($this->options->{'enforce-refs'}) ? true : false;
+		$this->exitIfError(($validator->validate($enforceRefs)));
 	}
 
 	public function describe()


### PR DESCRIPTION
This commit adds an `--enforce-refs` option that can be passed into `whippet deps validate` that will cause it to fail if a dependency in whippet.json is missing a "ref" property.

This will facilitate us in enabling automatic plugin updates, as we'll be able to update our shared whippet validation workflow to fail if references are missing, thereby ensuring that all dependencies have a reference and therefore can't be accidentally updated beyond e.g. a major version tag, or a specific pinned version.

Note that like the other checks in `whippet deps validate`, this does not check whether the reference provided exists and is valid, it just checks one is provided. An implicit check on the validity of the reference itself happens when `whippet deps update` or `whippet deps install` is run.

## How to test

1. Run the automated test suite with `./script/test`
2. Use a symlink or alias so you can run `/bin/whippet` from this repo (e.g. I have `whippet-dev` aliased to that file)
3. Clone https://github.com/dxw/wordpress-template, and run your equivalent of `whippet-dev deps validate -r` on that repo. It should fail
4. Replace the template `whippet.json` with:
   ```json
   {
    "src": {
        "plugins": "git@github.com:dxw-wordpress-plugins/"
    },
    "plugins": [
        {"name": "akismet", "ref": "v5"},
        {"name": "advanced-custom-fields-pro", "ref": "v6"}
    ]
   }
   ```
5. Run `whippet deps update`, then run `whippet-dev deps validate -r` again. Validation should now pass.


- [x] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
