### PR TITLE
Chore/do not use old endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Use current dxw Git URIs for documentation and tests
+
 ## [v2.5.0] - 2024-07-24
 
 ### Added

--- a/docs/support.md
+++ b/docs/support.md
@@ -21,8 +21,8 @@ Manually edit the `whippet.json` file to add an entry to the "plugins" section f
 ```
 {
     "src": {
-        "plugins": "git@git.govpress.com:wordpress-plugins/",
-        "themes": "git@git.govpress.com:wordpress-themes/"
+        "plugins": "git@github.com:dxw-wordpress-plugins/",
+        "themes": "git@github.com:dxw/"
     },
     "plugins": [
         {"name": "akismet"}
@@ -40,8 +40,8 @@ And you want to add a plugin called "Foo", you would edit it to look like this:
 ```
 {
     "src": {
-        "plugins": "git@git.govpress.com:wordpress-plugins/",
-        "themes": "git@git.govpress.com:wordpress-themes/"
+        "plugins": "git@github.com:dxw-wordpress-plugins/",
+        "themes": "git@github.com:dxw/"
     },
     "plugins": [
         {"name": "akismet"},

--- a/docs/themesandplugins.md
+++ b/docs/themesandplugins.md
@@ -6,15 +6,15 @@ To manage plugins and themes using Whippet, you make entries in the `whippet.jso
 
 The file should specify a source for plugins and themes. The source should be a base url for a git repo.
 
-If you are a dxw customer, the source will be `git@git.govpress.com:wordpress-plugins/`. If not, we suggest using `https://github.com/wp-plugins` for plugins.
+If you are a dxw customer, the source will be `git@github.com:dxw-wordpress-plugins/`. If not, we suggest using `https://github.com/wp-plugins` for plugins.
 
 The rest of the file should specify plugins and themes that you want to install. Example:
 
 ```
 {
     "src": {
-        "plugins": "git@git.govpress.com:wordpress-plugins/",
-        "themes": "git@git.govpress.com:wordpress-themes/"
+        "plugins": "git@github.com:dxw-wordpress-plugins/",
+        "themes": "git@github.com:dxw/"
     },
     "plugins": [
         {"name": "akismet"}
@@ -30,7 +30,7 @@ The rest of the file should specify plugins and themes that you want to install.
 The `{"name": "akismet"}` instructs Whippet (on request) to install the most recent version of Akismet available in the repo. Whippet will determine a valid repo URL for the akismet plugin by appending the name to the source. In this example:
 
 ```
-git@git.govpress.com:wordpress-plugins/akismet
+git@github.com:dxw-wordpress-plugins/akismet
 ```
 
 You can also specify a particular label or branch that you want to use. Generally, this will either be master (the default) or a tag (for a specific version), but you can use any git reference. So you can do:

--- a/spec/dependencies/validator.spec.php
+++ b/spec/dependencies/validator.spec.php
@@ -57,7 +57,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an error', function () {
 					$whippetContents = '{
                         "src": {
-                            "plugins": "git@git.govpress.com:wordpress-plugins/"
+                            "plugins": "git@github.com:dxw-wordpress-plugins/"
                         },
                         "plugins": [
                             {"name": "akismet"},
@@ -77,7 +77,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an error', function () {
 					$whippetContents = '{
                             "src": {
-                                "plugins": "git@git.govpress.com:wordpress-plugins/"
+                                "plugins": "git@github.com:dxw-wordpress-plugins/"
                             },
                             "plugins": [
                                 {"name": "akismet"},
@@ -110,7 +110,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an error', function () {
 					$whippetContents = '{
                             "src": {
-                                "plugins": "git@git.govpress.com:wordpress-plugins/"
+                                "plugins": "git@github.com:dxw-wordpress-plugins/"
                             },
                             "plugins": [
                                 {"name": "akismet"},
@@ -146,7 +146,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an error', function () {
 					$whippetContents = '{
                             "src": {
-                                "plugins": "git@git.govpress.com:wordpress-plugins/"
+                                "plugins": "git@github.com:dxw-wordpress-plugins/"
                             },
                             "plugins": [
                                 {"name": "akismet"},
@@ -185,7 +185,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an error', function () {
 					$whippetContents = '{
 						"src": {
-							"plugins": "git@git.govpress.com:wordpress-plugins/"
+							"plugins": "git@github.com:dxw-wordpress-plugins/"
 						},
 						"plugins": [
 							{"name": "akismet", "ref": "v1"},
@@ -229,7 +229,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an ok result', function () {
 					$whippetContents = '{
 						"src": {
-							"plugins": "git@git.govpress.com:wordpress-plugins/"
+							"plugins": "git@github.com:dxw-wordpress-plugins/"
 						},
 						"plugins": [
 							{"name": "akismet", "ref": "v1"},
@@ -273,7 +273,7 @@ describe(\Dxw\Whippet\Dependencies\Validator::class, function () {
 				it('returns an ok result', function () {
 					$whippetContents = '{
                             "src": {
-                                "plugins": "git@git.govpress.com:wordpress-plugins/"
+                                "plugins": "git@github.com:dxw-wordpress-plugins/"
                             },
                             "plugins": [
                                 {"name": "akismet"},

--- a/src/Modules/Helpers/ManifestIo.php
+++ b/src/Modules/Helpers/ManifestIo.php
@@ -40,7 +40,7 @@ trait ManifestIo
 
 			if ($plugin == 'source') {
 				if (empty($data)) {
-					echo "Source is empty. It should just specify a repo root:\n\n  source = 'git@git.govpress.com:wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.";
+					echo "Source is empty. It should just specify a repo root:\n\n  source = 'git@github.com:dxw-wordpress-plugins/'\n\nWhippet will attempt to find a source for your plugins by appending the plugin name to this URL.";
 					exit(1);
 				}
 

--- a/tests/dependencies/installer_test.php
+++ b/tests/dependencies/installer_test.php
@@ -23,13 +23,13 @@ class DependenciesInstallerTest extends \PHPUnit\Framework\TestCase
 
 		$my_plugin = [
 			'name' => 'my-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 			'revision' => '123456',
 		];
 
 		$another_plugin = [
 			'name' => 'another-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/another-plugin',
 			'revision' => '789abc',
 		];
 
@@ -46,9 +46,9 @@ class DependenciesInstallerTest extends \PHPUnit\Framework\TestCase
 
 		$gitMyTheme = $this->getGit(false, 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906');
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/themes/my-theme', $gitMyTheme);
-		$gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456');
+		$gitMyPlugin = $this->getGit(false, 'git@github.com:dxw-wordpress-plugins/my-plugin', '123456');
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
-		$gitAnotherPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/another-plugin', '789abc');
+		$gitAnotherPlugin = $this->getGit(false, 'git@github.com:dxw-wordpress-plugins/another-plugin', '789abc');
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/another-plugin', $gitAnotherPlugin);
 
 		$inspection_check_results = function ($type, $dep) {
@@ -115,7 +115,7 @@ EOT;
 
 		$my_plugin = [
 			'name' => 'my-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 			'revision' => '123456',
 		];
 
@@ -127,7 +127,7 @@ EOT;
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-		$gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456');
+		$gitMyPlugin = $this->getGit(false, 'git@github.com:dxw-wordpress-plugins/my-plugin', '123456');
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
 
 		$inspection_check_results = function ($type, $dep) {
@@ -438,12 +438,12 @@ EOT;
 			'plugins' => [
 				[
 					'name' => 'my-plugin',
-					'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+					'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 					'revision' => '123456',
 				],
 				[
 					'name' => 'another-plugin',
-					'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
+					'src' => 'git@github.com:dxw-wordpress-plugins/another-plugin',
 					'revision' => '789abc',
 				],
 			],
@@ -499,19 +499,19 @@ EOT;
 			'plugins' => [
 				[
 					'name' => 'my-plugin',
-					'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+					'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 					'revision' => '123456',
 				],
 				[
 					'name' => 'another-plugin',
-					'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
+					'src' => 'git@github.com:dxw-wordpress-plugins/another-plugin',
 					'revision' => '789abc',
 				],
 			],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-		$gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456');
+		$gitMyPlugin = $this->getGit(false, 'git@github.com:dxw-wordpress-plugins/my-plugin', '123456');
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Installer(
@@ -544,19 +544,19 @@ EOT;
 			'plugins' => [
 				[
 					'name' => 'my-plugin',
-					'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+					'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 					'revision' => '123456',
 				],
 				[
 					'name' => 'another-plugin',
-					'src' => 'git@git.govpress.com:wordpress-plugins/another-plugin',
+					'src' => 'git@github.com:dxw-wordpress-plugins/another-plugin',
 					'revision' => '789abc',
 				],
 			],
 		]);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-		$gitMyPlugin = $this->getGit(false, 'git@git.govpress.com:wordpress-plugins/my-plugin', '123456', true);
+		$gitMyPlugin = $this->getGit(false, 'git@github.com:dxw-wordpress-plugins/my-plugin', '123456', true);
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Git\\Git', $dir.'/wp-content/plugins/my-plugin', $gitMyPlugin);
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Installer(

--- a/tests/dependencies/updater_test.php
+++ b/tests/dependencies/updater_test.php
@@ -69,7 +69,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
 				'themes' => 'git@git.govpress.com:wordpress-themes/',
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -96,12 +96,12 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
 		$whippetLock = $this->getWhippetLockWritable([
 			['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
-			['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
+			['plugins', 'my-plugin', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'd961c3d'],
 		], sha1('foobar'), $dir.'/whippet.lock', []);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
 			$this->getFactory(),
@@ -431,7 +431,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
 				'themes' => 'git@git.govpress.com:wordpress-themes/',
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -458,12 +458,12 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
 		$whippetLock = $this->getWhippetLockWritable([
 			['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
-			['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
+			['plugins', 'my-plugin', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'd961c3d'],
 		], sha1('foobar'), $dir.'/whippet.lock', []);
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
 			$this->getFactory(),
@@ -519,7 +519,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
 			$this->getFactory(),
@@ -561,7 +561,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
 				'themes' => 'git@git.govpress.com:wordpress-themes/',
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -588,12 +588,12 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
 		$whippetLock = $this->getWhippetLockWritable([
 			['themes', 'my-theme', 'git@git.govpress.com:wordpress-themes/my-theme', '27ba906'],
-			['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
+			['plugins', 'my-plugin', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'd961c3d'],
 		], sha1('foobar'), $dir.'/whippet.lock', []);
 		$this->addFactoryNewInstance('\\Dxw\\Whippet\\Files\\WhippetLock', [], $whippetLock);
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::err('file not found'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
@@ -615,7 +615,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -644,7 +644,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
 			$this->getFactory(),
@@ -709,7 +709,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		file_put_contents($dir.'/whippet.json', 'foobar');
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -749,7 +749,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -778,7 +778,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
 			$this->getFactory(),
@@ -954,7 +954,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
 				'themes' => 'git@git.govpress.com:wordpress-themes/',
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -1057,7 +1057,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
 				'themes' => 'git@git.govpress.com:wordpress-themes/',
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -1088,7 +1088,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-themes/my-theme', 'v1.4', \Result\Result::ok('27ba906'));
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$dependencies = new \Dxw\Whippet\Dependencies\Updater(
 			$this->getFactory(),
@@ -1111,7 +1111,7 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 
 		$whippetJson = $this->getWhippetJson([
 			'src' => [
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 			'themes' => [
 				[
@@ -1129,12 +1129,12 @@ class Dependencies_Updater_Test extends \PHPUnit\Framework\TestCase
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetJson', 'fromFile', $dir.'/whippet.json', \Result\Result::ok($whippetJson));
 
 		$whippetLock = $this->getWhippetLockWritable([
-			['plugins', 'my-plugin', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'd961c3d'],
+			['plugins', 'my-plugin', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'd961c3d'],
 		], sha1('foobar'), $dir.'/whippet.lock', []);
 
 		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Files\\WhippetLock', 'fromFile', $dir.'/whippet.lock', \Result\Result::ok($whippetLock));
 
-		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@git.govpress.com:wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
+		$this->addFactoryCallStatic('\\Dxw\\Whippet\\Git\\Git', 'ls_remote', 'git@github.com:dxw-wordpress-plugins/my-plugin', 'v1.6', \Result\Result::ok('d961c3d'));
 
 		$gitignore = $this->getGitignore(["/wp-content/themes/my-theme\n",
 		"/wp-content/plugins/my-plugin\n", ], [

--- a/tests/files/whippet_json_test.php
+++ b/tests/files/whippet_json_test.php
@@ -28,12 +28,12 @@ class Files_WhippetJson_Test extends \PHPUnit\Framework\TestCase
 	{
 		$whippetJson = new \Dxw\Whippet\Files\WhippetJson([
 			'src' => [
-				'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+				'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 			],
 		]);
 
 		$this->assertEquals([
-			'plugins' => 'git@git.govpress.com:wordpress-plugins/',
+			'plugins' => 'git@github.com:dxw-wordpress-plugins/',
 		], $whippetJson->getSources());
 	}
 

--- a/tests/services/inspection_checker_test.php
+++ b/tests/services/inspection_checker_test.php
@@ -31,7 +31,7 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
 
 		$my_plugin = [
 			'name' => 'my-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 			'revision' => '123456',
 		];
 		$checker = new \Dxw\Whippet\Services\InspectionChecker($api);
@@ -46,7 +46,7 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
 
 		$my_plugin = [
 			'name' => 'my-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 			'revision' => '123456',
 		];
 		$checker = new \Dxw\Whippet\Services\InspectionChecker($api);
@@ -75,7 +75,7 @@ EOT;
 
 		$my_plugin = [
 			'name' => 'my-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 			'revision' => '123456',
 		];
 		$checker = new \Dxw\Whippet\Services\InspectionChecker($api);
@@ -103,7 +103,7 @@ EOT;
 
 		$my_plugin = [
 			'name' => 'my-plugin',
-			'src' => 'git@git.govpress.com:wordpress-plugins/my-plugin',
+			'src' => 'git@github.com:dxw-wordpress-plugins/my-plugin',
 			'revision' => '123456',
 		];
 		$checker = new \Dxw\Whippet\Services\InspectionChecker($api);


### PR DESCRIPTION
Update docs and test to use current Git URIs.

## Testing

Check CI pipeline runs green.

----

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
