### PR TITLE
Chore/small fixes

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,13 @@
-<phpunit bootstrap="tests/Helpers.php" backupGlobals="false" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/Helpers.php" backupGlobals="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="unit_and_integration">
       <directory suffix="_test.php">tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/spec/dependencies/dependency_types.spec.php
+++ b/spec/dependencies/dependency_types.spec.php
@@ -1,0 +1,9 @@
+<?php
+
+describe(\Dxw\Whippet\Dependencies\DependencyTypes::class, function () {
+	context("getDependencyTypes()", function () {
+		it('returns a list of dependencies as strings', function () {
+			expect(\Dxw\Whippet\Dependencies\DependencyTypes::getDependencyTypes())->toBe(['themes', 'plugins']);
+		});
+	});
+});

--- a/src/Dependencies/DependencyTypes.php
+++ b/src/Dependencies/DependencyTypes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Dxw\Whippet\Dependencies;
+
+class DependencyTypes
+{
+	public const PLUGINS = 'plugins';
+	public const THEMES = 'themes';
+
+
+	public static function getDependencyTypes()
+	{
+
+		return [DependencyTypes::THEMES, DependencyTypes::PLUGINS];
+	}
+}

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -22,10 +22,9 @@ class Describer
 		if ($resultLoad->isErr()) {
 			return $resultLoad;
 		}
-		$dependencyTypes = ['themes', 'plugins'];
 		$git = new \Dxw\Whippet\Git\Git($this->dir);
 		$results = [];
-		foreach ($dependencyTypes as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			foreach ($this->lockFile->getDependencies($type) as $dep) {
 				$result = $git::tag_for_commit($dep['src'], $dep['revision']);
 				if ($result->isErr()) {

--- a/src/Dependencies/Installer.php
+++ b/src/Dependencies/Installer.php
@@ -28,7 +28,7 @@ class Installer
 
 		$dependencies = [];
 
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$dependencies[$type] = $this->lockFile->getDependencies($type);
 		}
 

--- a/src/Dependencies/Updater.php
+++ b/src/Dependencies/Updater.php
@@ -57,7 +57,7 @@ class Updater
 
 		$allDependencies = [];
 
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$allDependencies[$type] = $this->jsonFile->getDependencies($type);
 		}
 
@@ -133,7 +133,7 @@ class Updater
 
 	private function createGitIgnore()
 	{
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			foreach ($this->jsonFile->getDependencies($type) as $dep) {
 				$this->addDependencyToIgnoresArray($type, $dep['name']);
 			}
@@ -151,7 +151,7 @@ class Updater
 		}
 
 		// Iterate through locked dependencies and remove from gitignore
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			foreach ($this->lockFile->getDependencies($type) as $dep) {
 				$line = $this->getGitignoreDependencyLine($type, $dep['name']);
 				$index = array_search($line, $this->ignores);

--- a/src/Dependencies/Validator.php
+++ b/src/Dependencies/Validator.php
@@ -46,7 +46,7 @@ class Validator
 
 		// Check that entries in whippet.json
 		// match entries in whippet.lock
-		foreach (['themes', 'plugins'] as $type) {
+		foreach (DependencyTypes::getDependencyTypes() as $type) {
 			$whippetJsonDependencies = $whippetJson->getDependencies($type);
 			$whippetLockDependencies = $whippetLock->getDependencies($type);
 			if (count($whippetJsonDependencies) !== count($whippetLockDependencies)) {

--- a/src/Git/Gitignore.php
+++ b/src/Git/Gitignore.php
@@ -45,7 +45,7 @@ class Gitignore
 	private function ensure_closing_newline($ignores)
 	{
 		$index_of_last_line = count($ignores) - 1;
-		$last_line = $ignores[$index_of_last_line];
+		$last_line = $index_of_last_line >= 0 ? $ignores[$index_of_last_line] : 0;
 		$last_character = substr($last_line, -1);
 
 		if ($last_character != "\n") {

--- a/tests/services/inspection_checker_test.php
+++ b/tests/services/inspection_checker_test.php
@@ -35,7 +35,8 @@ class Inspection_Checker_Test extends \PHPUnit\Framework\TestCase
 			'revision' => '123456',
 		];
 		$checker = new \Dxw\Whippet\Services\InspectionChecker($api);
-		$checker->check('plugins', $my_plugin);
+		$result = $checker->check('plugins', $my_plugin);
+		$this->assertFalse($result->isErr());
 	}
 
 	public function testPluginWithNoInspectionsGeneratesMessage()

--- a/tests/services/inspections_api_test.php
+++ b/tests/services/inspections_api_test.php
@@ -16,7 +16,9 @@ class Inspections_Api_Test extends \PHPUnit\Framework\TestCase
 			->andReturn(\Result\Result::ok([]));
 
 		$api = new \Dxw\Whippet\Services\InspectionsApi('https://advisories.dxw.com', '/wp-json/v1/inspections/', $json_api);
-		$api->getInspections('my-plugin');
+		$result = $api->getInspections('my-plugin');
+		$this->assertFalse($result->isErr());
+		$this->assertEquals([], $result->unwrap());
 	}
 
 	public function testNoInspections()

--- a/tests/services/json_api_test.php
+++ b/tests/services/json_api_test.php
@@ -16,7 +16,9 @@ class Json_Api_Test extends \PHPUnit\Framework\TestCase
 			->andReturn(\Result\Result::ok('[]'));
 
 		$api = new \Dxw\Whippet\Services\JsonApi($base_api);
-		$api->get('http://apisite.com/api/endpoint');
+		$result = $api->get('http://apisite.com/api/endpoint');
+		$this->assertFalse($result->isErr());
+		$this->assertEquals([], $result->unwrap());
 	}
 
 	public function testEmptyResponse()


### PR DESCRIPTION
This PR contains the first few commits from #224 which are repo chores:

* Bring phpunit config up to date
* Add some assertions to test which didn't have any
* Fix an error which is triggered when `.gitignore` is empty
* Refactor dependency types into public consts

I haven't updated the ChangeLog because none of this is user-facing. 

I'm also going to close PR #224, it could possibly be fixed but I realised I made a design decision early on that was misguided and makes the code messier, so probably it would be better to split the PR into smaller PRs if we do move it forward.

