### PR TITLE
Alphabetise `whippet deps describe` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use current dxw Git URIs for documentation and tests
+- The output of `whippet deps describe` is alphabetised
 
 ## [v2.5.0] - 2024-07-24
 

--- a/src/Dependencies/Describer.php
+++ b/src/Dependencies/Describer.php
@@ -32,6 +32,9 @@ class Describer
 				}
 				$results[$type][$dep["name"]] = $result->unwrap();
 			}
+			if (array_key_exists($type, $results) && is_array($results[$type])) {
+				ksort($results[$type]);
+			}
 		}
 		$pretty_results = json_encode($results, JSON_PRETTY_PRINT);
 		printf($pretty_results);


### PR DESCRIPTION
This should, in particular, make the diffs of `whippet deps describe` we use to auto-generate PR comments describing the version changes easier to parse.

## How to test

1. Clone a repo that has a non-alphabetised `whippet.lock` file, e.g. https://github.com/dxw/ukgovcamp
2. On `main`, run `whippet deps describe` and the list of plugins should reflect the order they appear in `whippet.lock`
3. On this branch, run the same command again, and the list of plugins should be alphabetised

- [x] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
