### PR TITLE
Allow apps to deploy different WP Core versions on prod

### DIFF
--- a/src/Modules/Release.php
+++ b/src/Modules/Release.php
@@ -79,7 +79,8 @@ class Release
 		$wp = new \Dxw\Whippet\Git\Git($this->release_dir);
 		$wp->clone_repo($this->application_config->wordpress->repository);
 
-		if (getenv('WP_CONFIG_WP_ENVIRONMENT_TYPE') === false) {
+		if ((getenv('WP_CONFIG_WP_ENVIRONMENT_TYPE') === false || getenv('WP_CONFIG_WP_ENVIRONMENT_TYPE') === 'production') ||
+			(getenv('WP_ENVIRONMENT_TYPE') === false || getenv('WP_ENVIRONMENT_TYPE') === 'production')) {
 			// On production environments we deploy the WP Core revision
 			// described in the application config, which will normally be the
 			// major version tag of the latest WordPress release, e.g. v6.


### PR DESCRIPTION
Previously we deployed the same WP Core version on all environments. To descibe the version of Core that we wish to deploy we use a movable tag, which is usually the major version tag of the latest release, e.g. 'v6'.

However, this means that for patch and minor version updates, moving the movable tag will change deploys on both staging and production.

This commit changes that strategy, and if there is an no environment variable defined that looks like it describes a production environment, we try to deploy to a revision called 'latest' and then fall back to the revision from the JSON file if that does not exist.

Environment variables that might describe a production environment are:

* 'WP_ENVIRONMENT_TYPE' - found in wp-config.php
* 'WP_CONFIG_WP_ENVIRONMENT_TYPE' - specific to dxw

---

Resolves: https://...

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [ ] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
