### PR TITLE
Release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.7.0]
 
 ### Changed
 - Brew installs PHP 8


### PR DESCRIPTION
This is a breaking change which removes support for versions of PHP less than 8.

Resolves: https://...

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [-] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
