### PR TITLE
Fix/dependency warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+- PHP 8 deprecation warning in WhippetHelpers
+
 ## [v2.7.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.7.1]
 
 ## Fixed
 - PHP 8 deprecation warning in WhippetHelpers

--- a/src/Modules/Helpers/WhippetHelpers.php
+++ b/src/Modules/Helpers/WhippetHelpers.php
@@ -6,6 +6,7 @@ trait WhippetHelpers
 {
 	private $plugins_manifest_file;
 	private $project_dir;
+	private $plugin_dir;
 	private $application_config;
 	private $plugins_lock_file;
 

--- a/src/WhippetGenerator.php
+++ b/src/WhippetGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Dxw\Whippet;
 
+/** @psalm-suppress UnusedClass */
 abstract class WhippetGenerator
 {
 	use \Dxw\Whippet\Modules\Helpers\WhippetHelpers;


### PR DESCRIPTION
Add missing class attribute to fix:


    Creation of dynamic property Dxw\Whippet\Modules\Release::$plugin_dir
    is deprecated in .../Modules/Helpers/WhippetHelpers.php on line 40

Note that this is fine in PHP 8.2 which runs on my machine, but other colleagues have PHP 8.4 which gives a number of deprecation warnings in dependencies. The `platform` constraint in `composer.json` prevents us from updating further, and we should probably start taking a view on these upgrades soon.