### PR TITLE
Guard against unparsable Git URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+- Do not check for archived repo if Git URL cannot be parsed
+
 ## [v2.7.1]
 
 ## Fixed

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -57,28 +57,32 @@ class Git
 		if (!$this->is_github_repository($repository)) {
 			return;
 		}
-		$baseurl = 'https://api.github.com/repos';  # Must not have a trailing slash.
-		$substrings = explode('/', $repository);
-		$num_substrings = count($substrings);
-		# If the URL is http formatted: ['https', 'github.com', 'org', 'repo']
-		# If the URL is ssh formatted: ['git@git.github.com:org', 'repo']
-		if ($num_substrings < 2) {
-			return false;
-		}
-		$repo =  $substrings[$num_substrings - 1];
-		if (false !== strpos($repo, '.git')) {  # repo.git
-			$repo = str_replace('.git', '', $repo);
-		}
+		try {
+			$baseurl = 'https://api.github.com/repos';  # Must not have a trailing slash.
+			$substrings = explode('/', $repository);
+			$num_substrings = count($substrings);
+			# If the URL is http formatted: ['https', 'github.com', 'org', 'repo']
+			# If the URL is ssh formatted: ['git@git.github.com:org', 'repo']
+			if ($num_substrings < 2) {
+				return false;
+			}
+			$repo =  $substrings[$num_substrings - 1];
+			if (false !== strpos($repo, '.git')) {  # repo.git
+				$repo = str_replace('.git', '', $repo);
+			}
 
-		if (false !== strpos($repository, '@')) {
-			# ssh formatted...
-			$org = explode(':', $substrings[$num_substrings - 2])[1];
-		} else {
-			# http formatted...
-			$org =  $substrings[$num_substrings - 2];
+			if (false !== strpos($repository, '@')) {
+				# ssh formatted...
+				$org = explode(':', $substrings[$num_substrings - 2])[1];
+			} else {
+				# http formatted...
+				$org =  $substrings[$num_substrings - 2];
+			}
+			$api_url = join('/', [$baseurl, $org, $repo]);
+		} catch (\Exception $exn) {
+			echo "WARNING: could not parse URL: " . $repository . " is archived.";
+			return;
 		}
-		$api_url = join('/', [$baseurl, $org, $repo]);
-
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_URL, $api_url);
 		curl_setopt($curl, CURLOPT_USERAGENT, 'Whippet');


### PR DESCRIPTION
On Saluki CI we have a recurring stack trace from this code:

    [Checking themes/twentytwentythree]
    PHP Warning:  Undefined array key 1 in .../whippet/src/Git/Git.php on line 75

Adding debug code to Saluki CI does not show a malformed Whippet file, or Git URL. The URL that cannot be parsed is:

    git@github.com:WordPress/twentytwentythree

Stepping through the code in a ubuntu-24:04 container or running Whippet locally does not reproduce the error.

So, this commit just adds a try/catch block to suppress the error message.

## Notes from Saluki

Example action log: https://github.com/dxw/saluki/actions/runs/21628069716/job/62333263136

Go to **Build WordPress app using sqlite database** step and scroll past all of the Ubuntu `apt` logs to see the stack trace, which is:

```php
[Checking themes/twentytwentythree]
PHP Warning:  Undefined array key 1 in /home/runner/work/saluki/saluki/whippet/src/Git/Git.php on line 75
PHP Stack trace:
PHP   1. {main}() /home/runner/work/saluki/saluki/whippet/bin/whippet:0
PHP   2. RubbishThorClone->start($argv = [0 => '/home/runner/work/saluki/saluki/whippet/bin/whippet', 1 => 'deps', 2 => 'install']) /home/runner/work/saluki/saluki/whippet/bin/whippet:26
PHP   3. Dxw\Whippet\Whippet->deps('install') phar:///home/runner/work/saluki/saluki/whippet/vendor.phar/vendor/dxw/rubbishthorclone/rubbish_thor_clone.class.php:70
PHP   4. Dxw\Whippet\Whippet->dependencies() /home/runner/work/saluki/saluki/whippet/src/Whippet.php:83
PHP   5. RubbishThorClone->start($argv = [0 => 'deps', 1 => 'install']) /home/runner/work/saluki/saluki/whippet/src/Whippet.php:78
PHP   6. Dxw\Whippet\Modules\Dependencies->install() phar:///home/runner/work/saluki/saluki/whippet/vendor.phar/vendor/dxw/rubbishthorclone/rubbish_thor_clone.class.php:70
PHP   7. Dxw\Whippet\Dependencies\Installer->installAll() /home/runner/work/saluki/saluki/whippet/src/Modules/Dependencies.php:61
PHP   8. Dxw\Whippet\Dependencies\Installer->install($dependencies = ['themes' => [0 => [...]], 'plugins' => []]) /home/runner/work/saluki/saluki/whippet/src/Dependencies/Installer.php:35
PHP   9. Dxw\Whippet\Dependencies\Installer->installDependency($type = 'themes', $dep = ['name' => 'twentytwentythree', 'src' => 'git@github.com:WordPress/twentytwentythree', 'revision' => '11440a5b38bae6882fc2c00b703d4bb95420a0f5']) /home/runner/work/saluki/saluki/whippet/src/Dependencies/Installer.php:63
PHP  10. Dxw\Whippet\Git\Git->checkout($revision = '11440a5b38bae6882fc2c00b703d4bb95420a0f5') /home/runner/work/saluki/saluki/whippet/src/Dependencies/Installer.php:124
PHP  11. Dxw\Whippet\Git\Git->check_is_archived_github_repository($repository = '***github.com/WordPress/twentytwentythree') /home/runner/work/saluki/saluki/whippet/src/Git/Git.php:102
HEAD is now at 11440a5 Update readme with archive info (#297)
```


----

- [ ] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
