### PR TITLE
Order dependencies alphabetically by name when saving to whippet.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Dependencies in `whippet.lock` are always alphabetically ordered by name (within each type)
+
 ## [v2.8.0]
 
 ### Changed

--- a/src/Files/WhippetLock.php
+++ b/src/Files/WhippetLock.php
@@ -42,4 +42,16 @@ class WhippetLock extends Base
 			'revision' => $revision,
 		];
 	}
+
+	public function saveToPath($path)
+	{
+		foreach (\Dxw\Whippet\Dependencies\DependencyTypes::getDependencyTypes() as $type) {
+			if (isset($this->data[$type])) {
+				usort($this->data[$type], function ($item1, $item2) {
+					return $item1['name'] <=> $item2['name'];
+				});
+			}
+		}
+		parent::saveToPath($path);
+	}
 }

--- a/tests/files/whippet_lock_test.php
+++ b/tests/files/whippet_lock_test.php
@@ -183,6 +183,38 @@ class Files_WhippetLock_Test extends \PHPUnit\Framework\TestCase
 		]), file_get_contents($dir.'/my-whippet.lock'), true);
 	}
 
+	public function testSaveToPathAlphabeticalOrdering()
+	{
+		$dir = $this->getDir();
+
+		$data = [
+			"plugins" => [
+				[
+					"name" => "zebra"
+				],
+				[
+					"name" => "aardvark"
+				]
+			]
+		];
+
+		$whippetLock = new \Dxw\Whippet\Files\WhippetLock($data);
+
+		$whippetLock->saveToPath($dir.'/my-whippet.lock');
+
+		$this->assertTrue(file_exists($dir.'/my-whippet.lock'));
+		$this->assertEquals([
+			"plugins" => [
+				[
+					"name" => "aardvark"
+				],
+				[
+					"name" => "zebra"
+				]
+			]
+		], json_decode(file_get_contents($dir.'/my-whippet.lock'), true));
+	}
+
 	public function testFromStringInvalid()
 	{
 		$output = \Dxw\Whippet\Files\WhippetLock::fromString('this is not json');


### PR DESCRIPTION
It's an ongoing problem that whippet updates reorder the whippet.lock file, which causes git to get confused, and gives us merge conflicts.

If the plugins in whippet.lock are always alphabetically ordered, it will hopefully reduce the volume of those incidents.

I've done this in the `WhippetLock` class rather than in the `Base` class, just in case there's a case where `saveToPath()` gets called and we don't want to do this (though at the moment, it only gets called on `WhippetLock`).

## How to test

1. Alias this repo's `bin/whippet` file locally so you can run it as an alternative to the default `whippet` command (e.g. as `whippet-dev`)
2. Set up a whippet repo where the dependencies in the `whippet.json` file are not ordered alphabetically by name
3. Confirm that when running standard `whippet deps update` it produces a `whippet.lock` also not alphabetically ordered by name
4. Confirm that when running `whippet-dev deps update` the `whippet.lock` is ordered alphabetically by name
5. Confirm that when running a single dependency update on standard whippet(e.g. `whippet deps update plugins/akismet`) it produces a `whippet.lock` where the updated dependency is last
6. Confirm that on this branch the equivalent command (e.g. `whippet-dev deps update plugins/akismet`) still keeps the dependencies in alphabetical order

- [x] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
