### PR TITLE
Refactor/skip fetch when local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Speed up dependency installation by checking whether a dependency commit already exists locally before running a full git fetch
+
 ## [v2.9.0]
 
 ### Removed

--- a/spec/git/git.spec.php
+++ b/spec/git/git.spec.php
@@ -7,7 +7,7 @@ use Kahlan\Plugin\Double;
 describe(Git::class, function () {
 	describe('->checkout()', function () {
 		context('when revision is already present locally', function () {
-			it('checks out directly and does not fetch or check remote archive status', function () {
+			it('checks remote URL and checks out directly without fetching', function () {
 				$git = Double::instance(['extends' => Git::class, 'args' => ['/path/to/repo']]);
 				$commandsRun = [];
 
@@ -15,7 +15,9 @@ describe(Git::class, function () {
 					$commandsRun[] = $cmd;
 					$cmdStr = implode(' ', $cmd);
 
-					if (strpos($cmdStr, 'cat-file') !== false) {
+					if (strpos($cmdStr, 'remote get-url') !== false) {
+						return [['https://example.org/repo'], 0];
+					} elseif (strpos($cmdStr, 'cat-file') !== false) {
 						return [[], 0];
 					} elseif (strpos($cmdStr, 'checkout') !== false) {
 						return [['Already on commit'], 0];
@@ -28,6 +30,7 @@ describe(Git::class, function () {
 
 				expect($result)->toBe(true);
 				expect($commandsRun)->toBe([
+					['git', 'remote', 'get-url', 'origin'],
 					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
 					['git', 'checkout', 'a1b2c3d4e5f6']
 				]);
@@ -35,7 +38,7 @@ describe(Git::class, function () {
 		});
 
 		context('when revision is not present locally', function () {
-			it('checks if the revision exists locally (fails), checks remote URL, fetches, and then checks out', function () {
+			it('checks remote URL, checks if the revision exists locally (fails), fetches, and then checks out', function () {
 				$git = Double::instance(['extends' => Git::class, 'args' => ['/path/to/repo']]);
 				$commandsRun = [];
 
@@ -58,8 +61,8 @@ describe(Git::class, function () {
 
 				expect($result)->toBe(true);
 				expect($commandsRun)->toBe([
-					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
 					['git', 'remote', 'get-url', 'origin'],
+					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
 					['git', 'fetch', '-a', '--force', '&&', 'git', 'checkout', 'a1b2c3d4e5f6']
 				]);
 			});

--- a/spec/git/git.spec.php
+++ b/spec/git/git.spec.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Dxw\Whippet\Git;
+
+use Kahlan\Plugin\Double;
+
+describe(Git::class, function () {
+	describe('->checkout()', function () {
+		context('when revision is already present locally', function () {
+			it('checks out directly and does not fetch or check remote archive status', function () {
+				$git = Double::instance(['extends' => Git::class, 'args' => ['/path/to/repo']]);
+				$commandsRun = [];
+
+				allow($git)->toReceive('run_command')->andRun(function ($cmd, $cd = true) use (&$commandsRun) {
+					$commandsRun[] = $cmd;
+					$cmdStr = implode(' ', $cmd);
+
+					if (strpos($cmdStr, 'cat-file') !== false) {
+						return [[], 0];
+					} elseif (strpos($cmdStr, 'checkout') !== false) {
+						return [['Already on commit'], 0];
+					}
+
+					return [[], 0];
+				});
+
+				$result = $git->checkout('a1b2c3d4e5f6');
+
+				expect($result)->toBe(true);
+				expect($commandsRun)->toBe([
+					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
+					['git', 'checkout', 'a1b2c3d4e5f6']
+				]);
+			});
+		});
+
+		context('when revision is not present locally', function () {
+			it('checks if the revision exists locally (fails), checks remote URL, fetches, and then checks out', function () {
+				$git = Double::instance(['extends' => Git::class, 'args' => ['/path/to/repo']]);
+				$commandsRun = [];
+
+				allow($git)->toReceive('run_command')->andRun(function ($cmd, $cd = true) use (&$commandsRun) {
+					$commandsRun[] = $cmd;
+					$cmdStr = implode(' ', $cmd);
+
+					if (strpos($cmdStr, 'cat-file') !== false) {
+						return [['not found'], 1];
+					} elseif (strpos($cmdStr, 'remote get-url') !== false) {
+						return [['https://example.org/repo'], 0];
+					} elseif (strpos($cmdStr, 'fetch') !== false) {
+						return [['fetched successfully'], 0];
+					}
+
+					return [[], 0];
+				});
+
+				$result = $git->checkout('a1b2c3d4e5f6');
+
+				expect($result)->toBe(true);
+				expect($commandsRun)->toBe([
+					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
+					['git', 'remote', 'get-url', 'origin'],
+					['git', 'fetch', '-a', '--force', '&&', 'git', 'checkout', 'a1b2c3d4e5f6']
+				]);
+			});
+		});
+	});
+});

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -101,6 +101,11 @@ class Git
 
 	public function checkout($revision)
 	{
+		if ($this->has_revision_locally($revision)) {
+			list($output, $return) = $this->run_command(['git', 'checkout', $revision]);
+			return $this->check_git_return('Checkout failed', $return, $output);
+		}
+
 		list($output, $return) = $this->run_command(['git', 'remote', 'get-url', 'origin']);
 		if ($return === 0) {
 			$this->check_is_archived_github_repository($output[0]);
@@ -109,6 +114,12 @@ class Git
 		list($output, $return) = $this->run_command(['git', 'fetch', '-a', '--force', '&&', 'git', 'checkout', $revision]);
 
 		return $this->check_git_return('Checkout failed', $return, $output);
+	}
+
+	private function has_revision_locally($revision)
+	{
+		list($output, $return) = $this->run_command(['git', 'cat-file', '-e', $revision . '^{commit}']);
+		return $return === 0;
 	}
 
 	public function hard_reset($revision = 'HEAD')

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -118,8 +118,8 @@ class Git
 
 	private function has_revision_locally($revision)
 	{
-		list($output, $return) = $this->run_command(['git', 'cat-file', '-e', $revision . '^{commit}']);
-		return $return === 0;
+		$result = $this->run_command(['git', 'cat-file', '-e', $revision . '^{commit}']);
+		return $result[1] === 0;
 	}
 
 	public function hard_reset($revision = 'HEAD')

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -101,14 +101,14 @@ class Git
 
 	public function checkout($revision)
 	{
-		if ($this->has_revision_locally($revision)) {
-			list($output, $return) = $this->run_command(['git', 'checkout', $revision]);
-			return $this->check_git_return('Checkout failed', $return, $output);
-		}
-
 		list($output, $return) = $this->run_command(['git', 'remote', 'get-url', 'origin']);
 		if ($return === 0) {
 			$this->check_is_archived_github_repository($output[0]);
+		}
+
+		if ($this->has_revision_locally($revision)) {
+			list($output, $return) = $this->run_command(['git', 'checkout', $revision]);
+			return $this->check_git_return('Checkout failed', $return, $output);
 		}
 
 		list($output, $return) = $this->run_command(['git', 'fetch', '-a', '--force', '&&', 'git', 'checkout', $revision]);


### PR DESCRIPTION
This PR significantly speed up the `whippet deps install` and `whippet deps update` commands where the commit referenced in `whippet.lock` already exists locally, by checking for it before doing a `git fetch`, rather than always doing a `git fetch` by default.

We still check for whether the repo is archived and emit a warning if so.

This PR was 99% authored by AntiGravity, with a little nudging on how to simplify Kahlan tests and pacify Psalm.

## How to test

1. Ensure you have an alias for the `bin/whippet` in this repo, e.g. `whippet-dev`
2. Choose a project repo where you already have the whippet deps installed locally
3. Compare the time it takes to run `whippet deps install` with `whippet-dev deps install` (e.g. use `time`)
4. Confirm that if you update the reference for a specific dependency in `whippet.json` `whippet-dev deps update` produces the correct outcome, but quicker that if you do the same operation as `whippet deps update`

- [x] Includes tests (if new features are introduced)
- [x] Changelog updated
