### PR TITLE
Fix/silence cat file stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-06-24
+
+### Changed
+
+- Do not output git error when checking for a commit that doesn't exist locally
+
 ## [v2.9.1] - 2026-06-24
 
 ### Changed

--- a/spec/git/git.spec.php
+++ b/spec/git/git.spec.php
@@ -31,7 +31,7 @@ describe(Git::class, function () {
 				expect($result)->toBe(true);
 				expect($commandsRun)->toBe([
 					['git', 'remote', 'get-url', 'origin'],
-					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
+					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}', '2>/dev/null'],
 					['git', 'checkout', 'a1b2c3d4e5f6']
 				]);
 			});
@@ -62,7 +62,7 @@ describe(Git::class, function () {
 				expect($result)->toBe(true);
 				expect($commandsRun)->toBe([
 					['git', 'remote', 'get-url', 'origin'],
-					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}'],
+					['git', 'cat-file', '-e', 'a1b2c3d4e5f6^{commit}', '2>/dev/null'],
 					['git', 'fetch', '-a', '--force', '&&', 'git', 'checkout', 'a1b2c3d4e5f6']
 				]);
 			});

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -16,7 +16,7 @@ namespace Dxw\Whippet\Git;
  **/
 class Git
 {
-	protected $command_separators = ['&&', '||'];
+	protected $command_separators = ['&&', '||', '2>/dev/null'];
 	private $repo_path;
 
 	public function __construct($repo_path)
@@ -118,7 +118,7 @@ class Git
 
 	private function has_revision_locally($revision)
 	{
-		$result = $this->run_command(['git', 'cat-file', '-e', $revision . '^{commit}']);
+		$result = $this->run_command(['git', 'cat-file', '-e', $revision . '^{commit}', '2>/dev/null']);
 		return $result[1] === 0;
 	}
 


### PR DESCRIPTION
This PR silences the error message from git when its can't find a dependency commit locally. By default this outputs an error like `fatal: Not a valid object name a1b2c3d4e5f6^{commit}`. The failure is expected and handled by the code, so the error is harmless, and the code completes successfully, but it's disconcerting output when running a `whippet deps update`.

- [x] Includes tests (if new features are introduced)
- [ ] Commit message includes link to the ticket/issue
- [x] Changelog updated
- [ ] PR open against [dxw's Homebrew Tap](https://github.com/dxw/homebrew-tap/) to point the Whippet formula to the new version number 
